### PR TITLE
fix(tor): eval auto-publish-enabled condition in phase `REGISTER_BEAN`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Fixed
+- fix: tor auto-publish can be disabled (`org.tbk.tor.auto-publish-enabled`)
+
 ### Added
 - disable p2p network activity by default for bitcoin testcontainer (`networkactive=0`)
 

--- a/spring-tor/spring-tor-autoconfigure/src/main/java/org/tbk/tor/spring/config/TorHiddenServiceAutoConfiguration.java
+++ b/spring-tor/spring-tor-autoconfigure/src/main/java/org/tbk/tor/spring/config/TorHiddenServiceAutoConfiguration.java
@@ -58,7 +58,7 @@ public class TorHiddenServiceAutoConfiguration {
     static class OnAutoPublishEnabledAndServerPortSpecified extends AllNestedConditions {
 
         OnAutoPublishEnabledAndServerPortSpecified() {
-            super(ConfigurationPhase.PARSE_CONFIGURATION);
+            super(ConfigurationPhase.REGISTER_BEAN);
         }
 
         @ConditionalOnProperty(name = "org.tbk.tor.auto-publish-enabled", havingValue = "true", matchIfMissing = true)
@@ -121,7 +121,7 @@ public class TorHiddenServiceAutoConfiguration {
         static class OnAutoPublishEnabledAndManagementServerPortSpecified extends AllNestedConditions {
 
             OnAutoPublishEnabledAndManagementServerPortSpecified() {
-                super(ConfigurationPhase.PARSE_CONFIGURATION);
+                super(ConfigurationPhase.REGISTER_BEAN);
             }
 
             @ConditionalOnProperty(name = "org.tbk.tor.auto-publish-enabled", havingValue = "true", matchIfMissing = true)

--- a/spring-tor/spring-tor-autoconfigure/src/test/java/org/tbk/tor/spring/config/TorAutoConfigurationTest.java
+++ b/spring-tor/spring-tor-autoconfigure/src/test/java/org/tbk/tor/spring/config/TorAutoConfigurationTest.java
@@ -111,6 +111,7 @@ public class TorAutoConfigurationTest {
     @Test
     public void torBeansCreatedInWebContext() {
         this.webContextRunner.withUserConfiguration(autoConfigClasses)
+                .withPropertyValues("server.port=13337")
                 .withBean(ServerProperties.class, () -> {
                     // fake a running webserver for the hidden service to bind to
                     ServerProperties serverProperties = new ServerProperties();
@@ -137,6 +138,13 @@ public class TorAutoConfigurationTest {
     public void torBeansCreatedInWebContextWithAutoPublishDisabled() {
         this.webContextRunner.withUserConfiguration(autoConfigClasses)
                 .withPropertyValues("org.tbk.tor.auto-publish-enabled=false")
+                .withPropertyValues("server.port=13337")
+                .withBean(ServerProperties.class, () -> {
+                    // fake a running webserver
+                    ServerProperties serverProperties = new ServerProperties();
+                    serverProperties.setPort(13337);
+                    return serverProperties;
+                })
                 .run(context -> {
                     autoPublishEnabledAndWebAppBeanNames.forEach(name -> {
                         boolean beanWithNameIsAvailable = context.containsBean(name);


### PR DESCRIPTION
Fixes #33.

Before this commit `org.tbk.tor.auto-publish-enabled=false` was not honored and a service definition was created if a `ServerProperties` bean was present.
After this commit, this property will be checked and if `false`, no service definition will be created.

Tests actually did not really cover the intended behaviour, as no server port has been specified and the condition was never met in the first place. Should be fixed now.