### PR TITLE
Update config properties in docs

### DIFF
--- a/modules.md
+++ b/modules.md
@@ -10,7 +10,7 @@ A module containing a spring boot starter for a [ConsensusJ](https://github.com/
 The starter will automatically create an injectable `BitcoinClient` bean:
 
 ```yaml
-org.tbk.bitcoin.jsonrpc.client:
+org.tbk.bitcoin.jsonrpc:
   enabled: true
   network: mainnet
   rpchost: http://localhost


### PR DESCRIPTION
The docs mention 'org.tbk.bitcoin.jsonrpc.client' as the prefix for all properties related to the jsonrpc-client module. However, the correct prefix is 'org.tbk.bitcoin.jsonrpc' (without the trailing '.client').