### PR TITLE
refactor(lnd-grpc-client): rename autoconfig properties

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - deprecation: scheduled `org.tbk.bitcoin.common.util.Hex` for removal
 - upgrade: update spring-boot from v3.0.2 to v3.0.4
 
+### Breaking
+- lnd-grpc-client: rename `rpchost` and `rpcport` properties to `host` and `port`
+
 ## [0.6.0] - 2023-02-23
 ### Added
 - module: initial version of module `bitcoin-zeromq-client-bitcoin-kmp`

--- a/examples/incubator/bitcoin-payment-request-example-application/src/main/java/org/tbk/bitcoin/example/payreq/BitcoinPaymentRequestExampleApplicationConfig.java
+++ b/examples/incubator/bitcoin-payment-request-example-application/src/main/java/org/tbk/bitcoin/example/payreq/BitcoinPaymentRequestExampleApplicationConfig.java
@@ -1,9 +1,7 @@
 package org.tbk.bitcoin.example.payreq;
 
-import com.google.common.io.CharStreams;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.compress.utils.IOUtils;
 import org.consensusj.bitcoin.jsonrpc.BitcoinExtendedClient;
 import org.lightningj.lnd.wrapper.SynchronousLndAPI;
 import org.lightningj.lnd.wrapper.message.GetInfoResponse;
@@ -73,14 +71,14 @@ public class BitcoinPaymentRequestExampleApplicationConfig {
             String macaroon = macaroonFromContainer(properties, lndContainer);
 
             String ip = "127.0.0.1";
-            Integer port = lndContainer.getMappedPort(properties.getRpcport());
+            Integer port = lndContainer.getMappedPort(properties.getPort());
             return String.format("lndconnect://%s:%d?cert=%s&macaroon=%s", ip, port, cert, macaroon);
         }
 
         private static String macaroonFromContainer(LndClientAutoConfigProperties properties,
                                                     LndContainer<?> lndContainer) {
             return lndContainer.copyFileFromContainer(properties.getMacaroonFilePath(), inputStream -> {
-                byte[] macaroon = IOUtils.toByteArray(inputStream);
+                byte[] macaroon = inputStream.readAllBytes();
                 return Base64.getUrlEncoder().encodeToString(macaroon);
             });
         }
@@ -89,7 +87,7 @@ public class BitcoinPaymentRequestExampleApplicationConfig {
                                                 LndContainer<?> lndContainer) {
             return lndContainer.copyFileFromContainer(properties.getCertFilePath(), inputStream -> {
                 try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream))) {
-                    List<String> lines = CharStreams.readLines(reader);
+                    List<String> lines = reader.lines().toList();
 
                     // remove '-----BEGIN CERTIFICATE-----', '-----END CERTIFICATE-----' and line breaks
                     String certBase64 = lines.stream()

--- a/examples/incubator/bitcoin-payment-request-example-application/src/main/java/org/tbk/bitcoin/example/payreq/lnd/CustomTestcontainerLndRpcConfig.java
+++ b/examples/incubator/bitcoin-payment-request-example-application/src/main/java/org/tbk/bitcoin/example/payreq/lnd/CustomTestcontainerLndRpcConfig.java
@@ -5,7 +5,6 @@ import io.grpc.netty.shaded.io.netty.handler.ssl.SslContext;
 import io.grpc.netty.shaded.io.netty.handler.ssl.SslContextBuilder;
 import io.grpc.netty.shaded.io.netty.handler.ssl.SslProvider;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.compress.utils.IOUtils;
 import org.lightningj.lnd.wrapper.MacaroonContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -26,11 +25,11 @@ public class CustomTestcontainerLndRpcConfig {
                                      MacaroonContext lndRpcMacaroonContext,
                                      SslContext lndRpcSslContext) {
         String host = lndContainer.getHost();
-        Integer mappedPort = lndContainer.getMappedPort(properties.getRpcport());
+        Integer mappedPort = lndContainer.getMappedPort(properties.getPort());
 
         return LndRpcConfigImpl.builder()
-                .rpchost(host)
-                .rpcport(mappedPort)
+                .host(host)
+                .port(mappedPort)
                 .macaroonContext(lndRpcMacaroonContext)
                 .sslContext(lndRpcSslContext)
                 .build();
@@ -40,8 +39,7 @@ public class CustomTestcontainerLndRpcConfig {
     public MacaroonContext lndRpcMacaroonContext(LndClientAutoConfigProperties properties,
                                                  LndContainer<?> lndContainer) {
         return lndContainer.copyFileFromContainer(properties.getMacaroonFilePath(), inputStream -> {
-            byte[] bytes = IOUtils.toByteArray(inputStream);
-            String hex = HexFormat.of().formatHex(bytes);
+            String hex = HexFormat.of().formatHex(inputStream.readAllBytes());
             return () -> hex;
         });
     }

--- a/examples/incubator/bitcoin-payment-request-example-application/src/main/resources/application.yml
+++ b/examples/incubator/bitcoin-payment-request-example-application/src/main/resources/application.yml
@@ -31,7 +31,6 @@ logging.level.org.springframework: INFO
 #logging.level.web: DEBUG
 logging.level.org.javamoney.moneta.Money: WARN
 
-
 spring.datasource.url: 'jdbc:sqlite:bitcoin_payment_request_example_application.db'
 spring.datasource.driver-class-name: org.sqlite.JDBC
 spring.datasource.hikari.pool-name: SQLitePool
@@ -46,7 +45,6 @@ spring.datasource.hikari.auto-commit: true #default auto-commit behavior.
 spring.jpa.properties.hibernate.dialect: org.hibernate.community.dialect.SQLiteDialect
 spring.jpa.properties.hibernate.jdbc.time_zone: UTC
 
-
 org.tbk.spring.testcontainer.lnd:
   enabled: true
   restport: 20080
@@ -58,8 +56,8 @@ org.tbk.spring.testcontainer.lnd:
 
 org.tbk.lightning.lnd.grpc:
   enabled: true
-  rpchost: localhost
-  rpcport: 20009
+  host: localhost
+  port: ${org.tbk.spring.testcontainer.lnd.rpcport}
   # path to the admin macaroon file within the container!
   macaroonFilePath: '/root/.lnd/data/chain/bitcoin/regtest/admin.macaroon'
   # path to the tls cert file within the container!
@@ -100,8 +98,8 @@ org.tbk.spring.testcontainer.electrumx:
   enabled: true # disable if you do not need this functionality
   rpchost: localhost
   rpcport: 18443
-  rpcuser: myoneandonlyrpcuser
-  rpcpass: correcthorsebatterystaple123
+  rpcuser: ${org.tbk.spring.testcontainer.bitcoind.rpcuser}
+  rpcpass: ${org.tbk.spring.testcontainer.bitcoind.rpcpassword}
   environment:
     NET: regtest
     COIN: BitcoinSegwit
@@ -126,11 +124,11 @@ org.tbk.bitcoin.jsonrpc:
   network: regtest
   rpchost: http://localhost
   rpcport: 18443
-  rpcuser: myoneandonlyrpcuser
-  rpcpassword: correcthorsebatterystaple123
+  rpcuser: ${org.tbk.spring.testcontainer.bitcoind.rpcuser}
+  rpcpassword: ${org.tbk.spring.testcontainer.bitcoind.rpcpassword}
 
 org.tbk.bitcoin.zeromq:
-  network: regtest
+  network: ${org.tbk.bitcoin.jsonrpc.network}
   zmqpubrawblock: tcp://localhost:28332
   zmqpubrawtx: tcp://localhost:28333
 

--- a/examples/lnd-playground-example-application/src/main/java/org/tbk/lightning/lnd/playground/example/CustomTestcontainerLndRpcConfig.java
+++ b/examples/lnd-playground-example-application/src/main/java/org/tbk/lightning/lnd/playground/example/CustomTestcontainerLndRpcConfig.java
@@ -5,7 +5,6 @@ import io.grpc.netty.shaded.io.netty.handler.ssl.SslContext;
 import io.grpc.netty.shaded.io.netty.handler.ssl.SslContextBuilder;
 import io.grpc.netty.shaded.io.netty.handler.ssl.SslProvider;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.compress.utils.IOUtils;
 import org.lightningj.lnd.wrapper.MacaroonContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -26,11 +25,11 @@ public class CustomTestcontainerLndRpcConfig {
                                      MacaroonContext lndRpcMacaroonContext,
                                      SslContext lndRpcSslContext) {
         String host = lndContainer.getHost();
-        Integer mappedPort = lndContainer.getMappedPort(properties.getRpcport());
+        Integer mappedPort = lndContainer.getMappedPort(properties.getPort());
 
         return LndRpcConfigImpl.builder()
-                .rpchost(host)
-                .rpcport(mappedPort)
+                .host(host)
+                .port(mappedPort)
                 .macaroonContext(lndRpcMacaroonContext)
                 .sslContext(lndRpcSslContext)
                 .build();
@@ -40,8 +39,7 @@ public class CustomTestcontainerLndRpcConfig {
     public MacaroonContext lndRpcMacaroonContext(LndClientAutoConfigProperties properties,
                                                  LndContainer<?> lndContainer) {
         return lndContainer.copyFileFromContainer(properties.getMacaroonFilePath(), inputStream -> {
-            byte[] bytes = IOUtils.toByteArray(inputStream);
-            String hex = HexFormat.of().formatHex(bytes);
+            String hex = HexFormat.of().formatHex(inputStream.readAllBytes());
             return () -> hex;
         });
     }

--- a/examples/lnd-playground-example-application/src/main/resources/application.yml
+++ b/examples/lnd-playground-example-application/src/main/resources/application.yml
@@ -36,8 +36,8 @@ org.tbk.spring.testcontainer.lnd:
 
 org.tbk.lightning.lnd.grpc:
   enabled: true
-  rpchost: localhost
-  rpcport: 20009
+  host: localhost
+  port: ${org.tbk.spring.testcontainer.lnd.rpcport}
   # path to the admin macaroon file within the container!
   macaroonFilePath: '/root/.lnd/data/chain/bitcoin/regtest/admin.macaroon'
   # path to the tls cert file within the container!
@@ -85,10 +85,10 @@ org.tbk.bitcoin.jsonrpc:
   network: regtest
   rpchost: http://localhost
   rpcport: 18443
-  rpcuser: myoneandonlyrpcuser
-  rpcpassword: correcthorsebatterystaple123
+  rpcuser: ${org.tbk.spring.testcontainer.bitcoind.rpcuser}
+  rpcpassword: ${org.tbk.spring.testcontainer.bitcoind.rpcpassword}
 
 org.tbk.bitcoin.zeromq:
-  network: regtest
+  network: ${org.tbk.bitcoin.jsonrpc.network}
   zmqpubrawblock: tcp://localhost:28332
   zmqpubrawtx: tcp://localhost:28333

--- a/lnd-grpc-client/lnd-grpc-client-autoconfigure/src/integTest/java/org/tbk/lightning/lnd/grpc/config/DisabledLndHealthIndicatorIntegrationTest.java
+++ b/lnd-grpc-client/lnd-grpc-client-autoconfigure/src/integTest/java/org/tbk/lightning/lnd/grpc/config/DisabledLndHealthIndicatorIntegrationTest.java
@@ -25,8 +25,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         "management.server.port=13337",
         "management.endpoint.health.show-details=always",
         "management.health.lndApi.enabled=false",
-        "org.tbk.lightning.lnd.grpc.rpchost=localhost",
-        "org.tbk.lightning.lnd.grpc.rpcport=13337",
+        "org.tbk.lightning.lnd.grpc.host=localhost",
+        "org.tbk.lightning.lnd.grpc.port=13337",
         "org.tbk.lightning.lnd.grpc.macaroonFilePath=/dev/null",
         "org.tbk.lightning.lnd.grpc.certFilePath=src/test/resources/lnd/tls-test.cert"
 })

--- a/lnd-grpc-client/lnd-grpc-client-autoconfigure/src/integTest/java/org/tbk/lightning/lnd/grpc/config/EnabledLndHealthIndicatorIntegrationTest.java
+++ b/lnd-grpc-client/lnd-grpc-client-autoconfigure/src/integTest/java/org/tbk/lightning/lnd/grpc/config/EnabledLndHealthIndicatorIntegrationTest.java
@@ -30,8 +30,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         "management.server.port=13337",
         "management.endpoint.health.show-details=always",
         "management.health.lndApi.enabled=true",
-        "org.tbk.lightning.lnd.grpc.rpchost=localhost",
-        "org.tbk.lightning.lnd.grpc.rpcport=13337",
+        "org.tbk.lightning.lnd.grpc.host=localhost",
+        "org.tbk.lightning.lnd.grpc.port=13337",
         "org.tbk.lightning.lnd.grpc.macaroonFilePath=/dev/null",
         "org.tbk.lightning.lnd.grpc.certFilePath=src/test/resources/lnd/tls-test.cert"
 })

--- a/lnd-grpc-client/lnd-grpc-client-autoconfigure/src/integTest/java/org/tbk/lightning/lnd/grpc/config/LndInfoContributorIntegrationTest.java
+++ b/lnd-grpc-client/lnd-grpc-client-autoconfigure/src/integTest/java/org/tbk/lightning/lnd/grpc/config/LndInfoContributorIntegrationTest.java
@@ -25,8 +25,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         "server.port=13337",
         "management.server.port=13337",
         "management.endpoints.web.exposure.include=info",
-        "org.tbk.lightning.lnd.grpc.rpchost=localhost",
-        "org.tbk.lightning.lnd.grpc.rpcport=13337",
+        "org.tbk.lightning.lnd.grpc.host=localhost",
+        "org.tbk.lightning.lnd.grpc.port=13337",
         "org.tbk.lightning.lnd.grpc.macaroonFilePath=/dev/null",
         "org.tbk.lightning.lnd.grpc.certFilePath=src/test/resources/lnd/tls-test.cert"
 })

--- a/lnd-grpc-client/lnd-grpc-client-autoconfigure/src/integTest/java/org/tbk/lightning/lnd/grpc/config/LndMetricsIntegrationTest.java
+++ b/lnd-grpc-client/lnd-grpc-client-autoconfigure/src/integTest/java/org/tbk/lightning/lnd/grpc/config/LndMetricsIntegrationTest.java
@@ -28,8 +28,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         "server.port=13337",
         "management.server.port=13337",
         "management.endpoints.web.exposure.include=metrics",
-        "org.tbk.lightning.lnd.grpc.rpchost=localhost",
-        "org.tbk.lightning.lnd.grpc.rpcport=13337",
+        "org.tbk.lightning.lnd.grpc.host=localhost",
+        "org.tbk.lightning.lnd.grpc.port=13337",
         "org.tbk.lightning.lnd.grpc.macaroonFilePath=/dev/null",
         "org.tbk.lightning.lnd.grpc.certFilePath=src/test/resources/lnd/tls-test.cert"
 })

--- a/lnd-grpc-client/lnd-grpc-client-autoconfigure/src/main/java/org/tbk/lightning/lnd/grpc/config/LndClientAutoConfigProperties.java
+++ b/lnd-grpc-client/lnd-grpc-client-autoconfigure/src/main/java/org/tbk/lightning/lnd/grpc/config/LndClientAutoConfigProperties.java
@@ -1,5 +1,6 @@
 package org.tbk.lightning.lnd.grpc.config;
 
+import com.google.common.base.Strings;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -31,15 +32,15 @@ public class LndClientAutoConfigProperties implements Validator {
     private Network network;
 
     /**
-     * IP address or hostname including http:// or https:// where lnd daemon is reachable.
-     * e.g. http://localhost, https://192.168.0.2, etc.
+     * IP address or hostname where lnd daemon is reachable.
+     * e.g. localhost, 192.168.0.2, etc.
      */
-    private String rpchost;
+    private String host;
 
     /**
      * Port where lnd daemon is listening.
      */
-    private int rpcport;
+    private int port;
 
     /**
      * Path to the cert file (e.g. /home/lnd/.lnd/tls.cert).
@@ -64,21 +65,14 @@ public class LndClientAutoConfigProperties implements Validator {
     public void validate(Object target, Errors errors) {
         LndClientAutoConfigProperties properties = (LndClientAutoConfigProperties) target;
 
-        if (properties.getRpcport() < 0) {
-            String errorMessage = String.format("Port must not be negative - invalid value: %d", properties.getRpcport());
-            errors.rejectValue("rpcport", "rpcport.invalid", errorMessage);
+        if (properties.getPort() <= 0) {
+            String errorMessage = String.format("Invalid 'port' value: %d", properties.getPort());
+            errors.rejectValue("port", "port.invalid", errorMessage);
         }
 
-        /*String rpchost = properties.getRpchost();
-        if (!Strings.isNullOrEmpty(rpchost)) {
-            boolean isHttp = rpchost.startsWith("http://");
-            boolean isHttps = rpchost.startsWith("https://");
-
-            boolean validProtocol = isHttp || isHttps;
-            if (!validProtocol) {
-                String errorMessage = String.format("Host must either start with 'http://' or 'https://' - invalid value: %s", rpchost);
-                errors.rejectValue("rpchost", "rpchost.invalid", errorMessage);
-            }
-        }*/
+        if (Strings.isNullOrEmpty(properties.getHost())) {
+            String errorMessage = String.format("Invalid `host` value: '%s'", properties.getHost());
+            errors.rejectValue("host", "host.invalid", errorMessage);
+        }
     }
 }

--- a/lnd-grpc-client/lnd-grpc-client-autoconfigure/src/main/java/org/tbk/lightning/lnd/grpc/config/LndClientAutoConfiguration.java
+++ b/lnd-grpc-client/lnd-grpc-client-autoconfigure/src/main/java/org/tbk/lightning/lnd/grpc/config/LndClientAutoConfiguration.java
@@ -100,16 +100,16 @@ public class LndClientAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean
     @ConditionalOnProperty({
-            "org.tbk.lightning.lnd.grpc.rpchost",
-            "org.tbk.lightning.lnd.grpc.rpcport"
+            "org.tbk.lightning.lnd.grpc.host",
+            "org.tbk.lightning.lnd.grpc.port"
     })
     @ConditionalOnBean({MacaroonContext.class, SslContext.class})
     public LndRpcConfig lndRpcConfig(
             @Qualifier("lndMacaroonContext") MacaroonContext lndMacaroonContext,
             @Qualifier("lndSslContext") SslContext lndSslContext) {
         return LndRpcConfigImpl.builder()
-                .rpchost(properties.getRpchost())
-                .rpcport(properties.getRpcport())
+                .host(properties.getHost())
+                .port(properties.getPort())
                 .macaroonContext(lndMacaroonContext)
                 .sslContext(lndSslContext)
                 .build();
@@ -124,8 +124,8 @@ public class LndClientAutoConfiguration {
     @ConditionalOnBean(LndRpcConfig.class)
     public SynchronousLndAPI synchronousLndAPI(LndRpcConfig rpcConfig) {
         return new SynchronousLndAPI(
-                rpcConfig.getRpchost(),
-                rpcConfig.getRpcport(),
+                rpcConfig.getHost(),
+                rpcConfig.getPort(),
                 rpcConfig.getSslContext(),
                 rpcConfig.getMacaroonContext());
     }
@@ -135,8 +135,8 @@ public class LndClientAutoConfiguration {
     @ConditionalOnBean(LndRpcConfig.class)
     public AsynchronousLndAPI lndAPI(LndRpcConfig rpcConfig) {
         return new AsynchronousLndAPI(
-                rpcConfig.getRpchost(),
-                rpcConfig.getRpcport(),
+                rpcConfig.getHost(),
+                rpcConfig.getPort(),
                 rpcConfig.getSslContext(),
                 rpcConfig.getMacaroonContext());
     }
@@ -147,8 +147,8 @@ public class LndClientAutoConfiguration {
     @ConditionalOnBean(LndRpcConfig.class)
     public SynchronousWalletUnlockerAPI synchronousLndWalletUnlockerAPI(LndRpcConfig rpcConfig) {
         return new SynchronousWalletUnlockerAPI(
-                rpcConfig.getRpchost(),
-                rpcConfig.getRpcport(),
+                rpcConfig.getHost(),
+                rpcConfig.getPort(),
                 rpcConfig.getSslContext(),
                 rpcConfig.getMacaroonContext());
     }
@@ -158,8 +158,8 @@ public class LndClientAutoConfiguration {
     @ConditionalOnBean(LndRpcConfig.class)
     public AsynchronousWalletUnlockerAPI lndWalletUnlockerAPI(LndRpcConfig rpcConfig) {
         return new AsynchronousWalletUnlockerAPI(
-                rpcConfig.getRpchost(),
-                rpcConfig.getRpcport(),
+                rpcConfig.getHost(),
+                rpcConfig.getPort(),
                 rpcConfig.getSslContext(),
                 rpcConfig.getMacaroonContext());
     }
@@ -170,8 +170,8 @@ public class LndClientAutoConfiguration {
     @ConditionalOnBean(LndRpcConfig.class)
     public SynchronousAutopilotAPI synchronousLndAutopilotAPI(LndRpcConfig rpcConfig) {
         return new SynchronousAutopilotAPI(
-                rpcConfig.getRpchost(),
-                rpcConfig.getRpcport(),
+                rpcConfig.getHost(),
+                rpcConfig.getPort(),
                 rpcConfig.getSslContext(),
                 rpcConfig.getMacaroonContext());
     }
@@ -181,8 +181,8 @@ public class LndClientAutoConfiguration {
     @ConditionalOnBean(LndRpcConfig.class)
     public AsynchronousAutopilotAPI lndAutopilotAPI(LndRpcConfig rpcConfig) {
         return new AsynchronousAutopilotAPI(
-                rpcConfig.getRpchost(),
-                rpcConfig.getRpcport(),
+                rpcConfig.getHost(),
+                rpcConfig.getPort(),
                 rpcConfig.getSslContext(),
                 rpcConfig.getMacaroonContext());
     }
@@ -193,8 +193,8 @@ public class LndClientAutoConfiguration {
     @ConditionalOnBean(LndRpcConfig.class)
     public SynchronousChainNotifierAPI synchronousLndChainNotifierAPI(LndRpcConfig rpcConfig) {
         return new SynchronousChainNotifierAPI(
-                rpcConfig.getRpchost(),
-                rpcConfig.getRpcport(),
+                rpcConfig.getHost(),
+                rpcConfig.getPort(),
                 rpcConfig.getSslContext(),
                 rpcConfig.getMacaroonContext());
     }
@@ -204,8 +204,8 @@ public class LndClientAutoConfiguration {
     @ConditionalOnBean(LndRpcConfig.class)
     public AsynchronousChainNotifierAPI lndChainNotifierAPI(LndRpcConfig rpcConfig) {
         return new AsynchronousChainNotifierAPI(
-                rpcConfig.getRpchost(),
-                rpcConfig.getRpcport(),
+                rpcConfig.getHost(),
+                rpcConfig.getPort(),
                 rpcConfig.getSslContext(),
                 rpcConfig.getMacaroonContext());
     }
@@ -216,8 +216,8 @@ public class LndClientAutoConfiguration {
     @ConditionalOnBean(LndRpcConfig.class)
     public SynchronousInvoicesAPI synchronousLndInvoiceAPI(LndRpcConfig rpcConfig) {
         return new SynchronousInvoicesAPI(
-                rpcConfig.getRpchost(),
-                rpcConfig.getRpcport(),
+                rpcConfig.getHost(),
+                rpcConfig.getPort(),
                 rpcConfig.getSslContext(),
                 rpcConfig.getMacaroonContext());
     }
@@ -227,8 +227,8 @@ public class LndClientAutoConfiguration {
     @ConditionalOnBean(LndRpcConfig.class)
     public AsynchronousInvoicesAPI lndInvoiceAPI(LndRpcConfig rpcConfig) {
         return new AsynchronousInvoicesAPI(
-                rpcConfig.getRpchost(),
-                rpcConfig.getRpcport(),
+                rpcConfig.getHost(),
+                rpcConfig.getPort(),
                 rpcConfig.getSslContext(),
                 rpcConfig.getMacaroonContext());
     }
@@ -239,8 +239,8 @@ public class LndClientAutoConfiguration {
     @ConditionalOnBean(LndRpcConfig.class)
     public SynchronousRouterAPI synchronousLndRouterAPI(LndRpcConfig rpcConfig) {
         return new SynchronousRouterAPI(
-                rpcConfig.getRpchost(),
-                rpcConfig.getRpcport(),
+                rpcConfig.getHost(),
+                rpcConfig.getPort(),
                 rpcConfig.getSslContext(),
                 rpcConfig.getMacaroonContext());
     }
@@ -250,8 +250,8 @@ public class LndClientAutoConfiguration {
     @ConditionalOnBean(LndRpcConfig.class)
     public AsynchronousRouterAPI lndRouterAPI(LndRpcConfig rpcConfig) {
         return new AsynchronousRouterAPI(
-                rpcConfig.getRpchost(),
-                rpcConfig.getRpcport(),
+                rpcConfig.getHost(),
+                rpcConfig.getPort(),
                 rpcConfig.getSslContext(),
                 rpcConfig.getMacaroonContext());
     }
@@ -262,8 +262,8 @@ public class LndClientAutoConfiguration {
     @ConditionalOnBean(LndRpcConfig.class)
     public SynchronousSignerAPI synchronousLndSignerAPI(LndRpcConfig rpcConfig) {
         return new SynchronousSignerAPI(
-                rpcConfig.getRpchost(),
-                rpcConfig.getRpcport(),
+                rpcConfig.getHost(),
+                rpcConfig.getPort(),
                 rpcConfig.getSslContext(),
                 rpcConfig.getMacaroonContext());
     }
@@ -273,8 +273,8 @@ public class LndClientAutoConfiguration {
     @ConditionalOnBean(LndRpcConfig.class)
     public AsynchronousSignerAPI lndSignerAPI(LndRpcConfig rpcConfig) {
         return new AsynchronousSignerAPI(
-                rpcConfig.getRpchost(),
-                rpcConfig.getRpcport(),
+                rpcConfig.getHost(),
+                rpcConfig.getPort(),
                 rpcConfig.getSslContext(),
                 rpcConfig.getMacaroonContext());
     }
@@ -285,8 +285,8 @@ public class LndClientAutoConfiguration {
     @ConditionalOnBean(LndRpcConfig.class)
     public SynchronousWalletKitAPI synchronousLndWalletKitAPI(LndRpcConfig rpcConfig) {
         return new SynchronousWalletKitAPI(
-                rpcConfig.getRpchost(),
-                rpcConfig.getRpcport(),
+                rpcConfig.getHost(),
+                rpcConfig.getPort(),
                 rpcConfig.getSslContext(),
                 rpcConfig.getMacaroonContext());
     }
@@ -296,8 +296,8 @@ public class LndClientAutoConfiguration {
     @ConditionalOnBean(LndRpcConfig.class)
     public AsynchronousWalletKitAPI lndWalletKitAPI(LndRpcConfig rpcConfig) {
         return new AsynchronousWalletKitAPI(
-                rpcConfig.getRpchost(),
-                rpcConfig.getRpcport(),
+                rpcConfig.getHost(),
+                rpcConfig.getPort(),
                 rpcConfig.getSslContext(),
                 rpcConfig.getMacaroonContext());
     }
@@ -308,8 +308,8 @@ public class LndClientAutoConfiguration {
     @ConditionalOnBean(LndRpcConfig.class)
     public SynchronousWatchtowerAPI synchronousLndWatchtowerAPI(LndRpcConfig rpcConfig) {
         return new SynchronousWatchtowerAPI(
-                rpcConfig.getRpchost(),
-                rpcConfig.getRpcport(),
+                rpcConfig.getHost(),
+                rpcConfig.getPort(),
                 rpcConfig.getSslContext(),
                 rpcConfig.getMacaroonContext());
     }
@@ -319,8 +319,8 @@ public class LndClientAutoConfiguration {
     @ConditionalOnBean(LndRpcConfig.class)
     public AsynchronousWatchtowerAPI lndWatchtowerAPI(LndRpcConfig rpcConfig) {
         return new AsynchronousWatchtowerAPI(
-                rpcConfig.getRpchost(),
-                rpcConfig.getRpcport(),
+                rpcConfig.getHost(),
+                rpcConfig.getPort(),
                 rpcConfig.getSslContext(),
                 rpcConfig.getMacaroonContext());
     }
@@ -331,8 +331,8 @@ public class LndClientAutoConfiguration {
     @ConditionalOnBean(LndRpcConfig.class)
     public SynchronousWatchtowerClientAPI synchronousLndWatchtowerClientAPI(LndRpcConfig rpcConfig) {
         return new SynchronousWatchtowerClientAPI(
-                rpcConfig.getRpchost(),
-                rpcConfig.getRpcport(),
+                rpcConfig.getHost(),
+                rpcConfig.getPort(),
                 rpcConfig.getSslContext(),
                 rpcConfig.getMacaroonContext());
     }
@@ -342,8 +342,8 @@ public class LndClientAutoConfiguration {
     @ConditionalOnBean(LndRpcConfig.class)
     public AsynchronousWatchtowerClientAPI lndWatchtowerClientAPI(LndRpcConfig rpcConfig) {
         return new AsynchronousWatchtowerClientAPI(
-                rpcConfig.getRpchost(),
-                rpcConfig.getRpcport(),
+                rpcConfig.getHost(),
+                rpcConfig.getPort(),
                 rpcConfig.getSslContext(),
                 rpcConfig.getMacaroonContext());
     }
@@ -354,8 +354,8 @@ public class LndClientAutoConfiguration {
     @ConditionalOnBean(LndRpcConfig.class)
     public SynchronousVersionerAPI synchronousLndVersionerAPI(LndRpcConfig rpcConfig) {
         return new SynchronousVersionerAPI(
-                rpcConfig.getRpchost(),
-                rpcConfig.getRpcport(),
+                rpcConfig.getHost(),
+                rpcConfig.getPort(),
                 rpcConfig.getSslContext(),
                 rpcConfig.getMacaroonContext());
     }
@@ -365,8 +365,8 @@ public class LndClientAutoConfiguration {
     @ConditionalOnBean(LndRpcConfig.class)
     public AsynchronousVersionerAPI lndVersionerAPI(LndRpcConfig rpcConfig) {
         return new AsynchronousVersionerAPI(
-                rpcConfig.getRpchost(),
-                rpcConfig.getRpcport(),
+                rpcConfig.getHost(),
+                rpcConfig.getPort(),
                 rpcConfig.getSslContext(),
                 rpcConfig.getMacaroonContext());
     }

--- a/lnd-grpc-client/lnd-grpc-client-autoconfigure/src/test/java/org/tbk/lightning/lnd/grpc/config/LndClientAutoConfigurationTest.java
+++ b/lnd-grpc-client/lnd-grpc-client-autoconfigure/src/test/java/org/tbk/lightning/lnd/grpc/config/LndClientAutoConfigurationTest.java
@@ -32,8 +32,8 @@ class LndClientAutoConfigurationTest {
     void beansAreCreated() {
         this.contextRunner.withUserConfiguration(LndClientAutoConfiguration.class)
                 .withPropertyValues(
-                        "org.tbk.lightning.lnd.grpc.rpchost=localhost",
-                        "org.tbk.lightning.lnd.grpc.rpcport=10001",
+                        "org.tbk.lightning.lnd.grpc.host=localhost",
+                        "org.tbk.lightning.lnd.grpc.port=10001",
                         "org.tbk.lightning.lnd.grpc.macaroonFilePath=/dev/null",
                         "org.tbk.lightning.lnd.grpc.certFilePath=src/test/resources/lnd/tls-test.cert"
                 )
@@ -75,8 +75,8 @@ class LndClientAutoConfigurationTest {
     void errorIfCertFileIsMissing() {
         this.contextRunner.withUserConfiguration(LndClientAutoConfiguration.class)
                 .withPropertyValues(
-                        "org.tbk.lightning.lnd.grpc.rpchost=localhost",
-                        "org.tbk.lightning.lnd.grpc.rpcport=10001",
+                        "org.tbk.lightning.lnd.grpc.host=localhost",
+                        "org.tbk.lightning.lnd.grpc.port=10001",
                         "org.tbk.lightning.lnd.grpc.macaroonFilePath=/dev/null",
                         "org.tbk.lightning.lnd.grpc.certFilePath=src/test/resources/lnd/tls-test-missing.cert"
                 ).run(context -> {

--- a/lnd-grpc-client/lnd-grpc-client-core/src/main/java/org/tbk/lightning/lnd/grpc/LndRpcConfig.java
+++ b/lnd-grpc-client/lnd-grpc-client-core/src/main/java/org/tbk/lightning/lnd/grpc/LndRpcConfig.java
@@ -11,14 +11,14 @@ public interface LndRpcConfig {
      *
      * @return IP address or hostname including http:// or https:// where lnd daemon is reachable.
      */
-    String getRpchost();
+    String getHost();
 
     /**
      * Port where lnd daemon is listening.
      *
      * @return Port where lnd daemon is listening.
      */
-    Integer getRpcport();
+    Integer getPort();
 
     /**
      * The {@link MacaroonContext} to access the lnd api.

--- a/lnd-grpc-client/lnd-grpc-client-core/src/main/java/org/tbk/lightning/lnd/grpc/LndRpcConfigImpl.java
+++ b/lnd-grpc-client/lnd-grpc-client-core/src/main/java/org/tbk/lightning/lnd/grpc/LndRpcConfigImpl.java
@@ -11,23 +11,23 @@ import org.lightningj.lnd.wrapper.MacaroonContext;
 public class LndRpcConfigImpl implements LndRpcConfig {
 
     /**
-     * IP address or hostname including http:// or https:// where lnd daemon is reachable.
-     * e.g. https://localhost:10001
+     * IP address or hostname where lnd daemon is reachable.
+     * e.g. localhost, 192.168.0.1
      *
-     * @param rpchost IP address or hostname including http:// or https:// where lnd daemon is reachable.
-     * @return IP address or hostname including http:// or https:// where lnd daemon is reachable.
+     * @param host IP address or hostname where lnd daemon is reachable.
+     * @return IP address or hostname where lnd daemon is reachable.
      */
     @NonNull
-    String rpchost;
+    String host;
 
     /**
      * Port where lnd daemon is listening.
      *
-     * @param rpcport Port where lnd daemon is listening.
+     * @param port Port where lnd daemon is listening.
      * @return Port where lnd daemon is listening.
      */
     @NonNull
-    Integer rpcport;
+    Integer port;
 
     /**
      * The {@link MacaroonContext} to access the lnd api.

--- a/modules.md
+++ b/modules.md
@@ -44,8 +44,8 @@ The starter will automatically create injectable `AsynchronousLndAPI` and `Synch
 ```yaml
 org.tbk.lightning.lnd.grpc:
   enabled: true
-  rpchost: localhost
-  rpcport: 10009
+  host: localhost
+  port: 10009
   macaroon-file-path: '/root/.lnd/data/chain/bitcoin/regtest/admin.macaroon'
   cert-file-path: '/root/.lnd/tls.cert'
 ```

--- a/spring-testcontainer/spring-testcontainer-electrum-daemon-example-application/src/main/java/org/tbk/spring/testcontainer/electrumd/example/CustomTestcontainerLndRpcConfig.java
+++ b/spring-testcontainer/spring-testcontainer-electrum-daemon-example-application/src/main/java/org/tbk/spring/testcontainer/electrumd/example/CustomTestcontainerLndRpcConfig.java
@@ -5,7 +5,6 @@ import io.grpc.netty.shaded.io.netty.handler.ssl.SslContext;
 import io.grpc.netty.shaded.io.netty.handler.ssl.SslContextBuilder;
 import io.grpc.netty.shaded.io.netty.handler.ssl.SslProvider;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.compress.utils.IOUtils;
 import org.lightningj.lnd.wrapper.MacaroonContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -26,11 +25,11 @@ public class CustomTestcontainerLndRpcConfig {
                                      MacaroonContext lndRpcMacaroonContext,
                                      SslContext lndRpcSslContext) {
         String host = lndContainer.getHost();
-        Integer mappedPort = lndContainer.getMappedPort(properties.getRpcport());
+        Integer mappedPort = lndContainer.getMappedPort(properties.getPort());
 
         return LndRpcConfigImpl.builder()
-                .rpchost(host)
-                .rpcport(mappedPort)
+                .host(host)
+                .port(mappedPort)
                 .macaroonContext(lndRpcMacaroonContext)
                 .sslContext(lndRpcSslContext)
                 .build();
@@ -40,8 +39,7 @@ public class CustomTestcontainerLndRpcConfig {
     public MacaroonContext lndRpcMacaroonContext(LndClientAutoConfigProperties properties,
                                                  LndContainer<?> lndContainer) {
         return lndContainer.copyFileFromContainer(properties.getMacaroonFilePath(), inputStream -> {
-            byte[] bytes = IOUtils.toByteArray(inputStream);
-            String hex = HexFormat.of().formatHex(bytes);
+            String hex = HexFormat.of().formatHex(inputStream.readAllBytes());
             return () -> hex;
         });
     }

--- a/spring-testcontainer/spring-testcontainer-electrum-daemon-example-application/src/main/resources/application.yml
+++ b/spring-testcontainer/spring-testcontainer-electrum-daemon-example-application/src/main/resources/application.yml
@@ -22,7 +22,7 @@ org.tbk.spring.testcontainer.electrum-daemon:
   enabled: true
   default-wallet: electrum/wallets/regtest/default_wallet
   environment:
-    ELECTRUM_NETWORK: regtest
+    ELECTRUM_NETWORK: ${org.tbk.bitcoin.jsonrpc.network}
     ELECTRUM_USER: electrum
     ELECTRUM_PASSWORD: correct_horse_battery_staple_20210508
 
@@ -30,17 +30,17 @@ org.tbk.bitcoin.electrum-daemon.jsonrpc:
   enabled: true
   rpchost: http://localhost
   rpcport: 7000
-  rpcuser: electrum
-  rpcpassword: correct_horse_battery_staple_20210508
+  rpcuser: ${org.tbk.spring.testcontainer.electrum-daemon.environment.ELECTRUM_USER}
+  rpcpassword: ${org.tbk.spring.testcontainer.electrum-daemon.environment.ELECTRUM_PASSWORD}
 
 org.tbk.spring.testcontainer.electrumx:
   enabled: true
-  rpcuser: this-is-my-rpc-user99
-  rpcpass: correct_horse_battery_staple_99
+  rpcuser: ${org.tbk.spring.testcontainer.bitcoind.rpcuser}
+  rpcpass: ${org.tbk.spring.testcontainer.bitcoind.rpcpassword}
   rpchost: localhost
   rpcport: 18443
   environment:
-    NET: regtest
+    NET: ${org.tbk.bitcoin.jsonrpc.network}
     COIN: BitcoinSegwit
     PEER_DISCOVERY: self
     PEER_ANNOUNCE: ''
@@ -57,8 +57,8 @@ org.tbk.spring.testcontainer.lnd:
 
 org.tbk.lightning.lnd.grpc:
   enabled: true
-  rpchost: localhost
-  rpcport: 19009
+  host: localhost
+  port: ${org.tbk.spring.testcontainer.lnd.rpcport}
   # path to the admin macaroon file within the container!
   macaroonFilePath: '/root/.lnd/data/chain/bitcoin/regtest/admin.macaroon'
   # path to the tls cert file within the container!
@@ -106,12 +106,12 @@ org.tbk.bitcoin.regtest:
 
 org.tbk.bitcoin.jsonrpc:
   network: regtest
-  rpcuser: this-is-my-rpc-user99
-  rpcpassword: correct_horse_battery_staple_99
   rpchost: http://localhost
   rpcport: 18443
+  rpcuser: ${org.tbk.spring.testcontainer.bitcoind.rpcuser}
+  rpcpassword: ${org.tbk.spring.testcontainer.bitcoind.rpcpassword}
 
 org.tbk.bitcoin.zeromq:
-  network: regtest
+  network: ${org.tbk.bitcoin.jsonrpc.network}
   zmqpubrawblock: tcp://localhost:28332
   zmqpubrawtx: tcp://localhost:28333

--- a/spring-testcontainer/spring-testcontainer-lnd-example-application/src/main/java/org/tbk/spring/testcontainer/lnd/example/CustomTestcontainerLndRpcConfig.java
+++ b/spring-testcontainer/spring-testcontainer-lnd-example-application/src/main/java/org/tbk/spring/testcontainer/lnd/example/CustomTestcontainerLndRpcConfig.java
@@ -5,7 +5,6 @@ import io.grpc.netty.shaded.io.netty.handler.ssl.SslContext;
 import io.grpc.netty.shaded.io.netty.handler.ssl.SslContextBuilder;
 import io.grpc.netty.shaded.io.netty.handler.ssl.SslProvider;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.compress.utils.IOUtils;
 import org.lightningj.lnd.wrapper.MacaroonContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -26,11 +25,11 @@ public class CustomTestcontainerLndRpcConfig {
                                      MacaroonContext lndRpcMacaroonContext,
                                      SslContext lndRpcSslContext) {
         String host = lndContainer.getHost();
-        Integer mappedPort = lndContainer.getMappedPort(properties.getRpcport());
+        Integer mappedPort = lndContainer.getMappedPort(properties.getPort());
 
         return LndRpcConfigImpl.builder()
-                .rpchost(host)
-                .rpcport(mappedPort)
+                .host(host)
+                .port(mappedPort)
                 .macaroonContext(lndRpcMacaroonContext)
                 .sslContext(lndRpcSslContext)
                 .build();
@@ -40,8 +39,7 @@ public class CustomTestcontainerLndRpcConfig {
     public MacaroonContext lndRpcMacaroonContext(LndClientAutoConfigProperties properties,
                                                  LndContainer<?> lndContainer) {
         return lndContainer.copyFileFromContainer(properties.getMacaroonFilePath(), inputStream -> {
-            byte[] bytes = IOUtils.toByteArray(inputStream);
-            String hex = HexFormat.of().formatHex(bytes);
+            String hex = HexFormat.of().formatHex(inputStream.readAllBytes());
             return () -> hex;
         });
     }

--- a/spring-testcontainer/spring-testcontainer-lnd-example-application/src/main/resources/application.yml
+++ b/spring-testcontainer/spring-testcontainer-lnd-example-application/src/main/resources/application.yml
@@ -29,8 +29,8 @@ org.tbk.spring.testcontainer.lnd:
 
 org.tbk.lightning.lnd.grpc:
   enabled: true
-  rpchost: localhost
-  rpcport: 19009
+  host: localhost
+  port: ${org.tbk.spring.testcontainer.lnd.rpcport}
   # path to the admin macaroon file within the container!
   macaroonFilePath: '/root/.lnd/data/chain/bitcoin/regtest/admin.macaroon'
   # path to the tls cert file within the container!
@@ -78,10 +78,10 @@ org.tbk.bitcoin.jsonrpc:
   network: regtest
   rpchost: http://localhost
   rpcport: 18443
-  rpcuser: this-is-my-rpc-user99
-  rpcpassword: correct_horse_battery_staple_99
+  rpcuser: ${org.tbk.spring.testcontainer.bitcoind.rpcuser}
+  rpcpassword: ${org.tbk.spring.testcontainer.bitcoind.rpcpassword}
 
 org.tbk.bitcoin.zeromq:
-  network: regtest
+  network: ${org.tbk.bitcoin.jsonrpc.network}
   zmqpubrawblock: tcp://localhost:28332
   zmqpubrawtx: tcp://localhost:28333

--- a/spring-testcontainer/spring-testcontainer-lnd-starter/src/integTest/resources/application-test.yml
+++ b/spring-testcontainer/spring-testcontainer-lnd-starter/src/integTest/resources/application-test.yml
@@ -9,8 +9,8 @@ org.tbk.spring.testcontainer.lnd:
 
 org.tbk.lightning.lnd.grpc:
   enabled: true
-  rpchost: localhost
-  rpcport: 19009
+  host: localhost
+  port: ${org.tbk.spring.testcontainer.lnd.rpcport}
   # path to the admin macaroon file within the container!
   macaroonFilePath: '/root/.lnd/data/chain/bitcoin/regtest/admin.macaroon'
   # path to the tls cert file within the container!


### PR DESCRIPTION
BREAKING CHANGE: rename `rpchost` and `rpcport` properties to `host` and `port`