### PR TITLE
fix: use strict typing for sqlite in payment request example app

### DIFF
--- a/bitcoin-jsr354/bitcoin-jsr354-format/src/main/java/org/tbk/bitcoin/format/BitcoinAmountFormat.java
+++ b/bitcoin-jsr354/bitcoin-jsr354-format/src/main/java/org/tbk/bitcoin/format/BitcoinAmountFormat.java
@@ -1,5 +1,7 @@
 package org.tbk.bitcoin.format;
 
+import org.tbk.bitcoin.currency.BitcoinCurrencyUnit;
+
 import javax.money.CurrencyUnit;
 import javax.money.Monetary;
 import javax.money.MonetaryAmount;
@@ -10,9 +12,18 @@ import javax.money.format.MonetaryParseException;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.text.ParseException;
+import java.util.Arrays;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public final class BitcoinAmountFormat implements MonetaryAmountFormat {
-    private static final String SEPARATOR = " ";
+    private static final String NBSP = "\u00A0"; // No-Break Space
+    private static final String NNBSP = "\u202F"; // Narrow No-Break Space
+    private static final String SEPARATOR = NBSP;
     private final AmountFormatContext context;
 
     BitcoinAmountFormat(AmountFormatContext context) {
@@ -31,31 +42,51 @@ public final class BitcoinAmountFormat implements MonetaryAmountFormat {
 
     @Override
     public MonetaryAmount parse(CharSequence text) throws MonetaryParseException {
-        String[] array = text.toString().split(SEPARATOR);
-        if (array.length != 2) {
+        String[] array = text.toString().split(" " + "|" + NBSP + "|" + NNBSP);
+
+        if (array.length < 2) {
             String errorMessage = String.format("An error happened when try to parse the Monetary Amount. "
-                    + "Expected length of 2 after split, but got: %d", array.length);
+                    + "Expected length of greater than or equal to 2 after split, but got: %d", array.length);
             throw new MonetaryParseException(errorMessage, text, 0);
         }
 
         CurrencyUnit currencyUnit = Monetary.getCurrency(array[0]);
-        BigDecimal number = new BigDecimal(array[1]);
 
-        return context.get(MonetaryAmountFactory.class)
-                .setCurrency(currencyUnit)
-                .setNumber(number)
-                .create();
+        DecimalFormat df = new DecimalFormat("#,###.#");
+        df.setMinimumFractionDigits(currencyUnit.getDefaultFractionDigits());
+        df.setMaximumFractionDigits(currencyUnit.getDefaultFractionDigits());
+        df.setParseBigDecimal(true);
+
+        String sanitizedNumberValue = Stream.of(array).skip(1)
+                .collect(Collectors.joining())
+                .replaceAll(NNBSP, "")
+                .replaceAll(NBSP, "")
+                .replaceAll(" ", "");
+        try {
+            return context.get(MonetaryAmountFactory.class)
+                    .setCurrency(currencyUnit)
+                    .setNumber(df.parse(sanitizedNumberValue))
+                    .create();
+        } catch (ParseException e) {
+            throw new MonetaryParseException(e.getMessage(), e.getErrorOffset());
+        }
     }
 
     @Override
     public String queryFrom(MonetaryAmount amount) {
+        DecimalFormat df = new DecimalFormat("#,###.#");
+        df.setMinimumFractionDigits(amount.getCurrency().getDefaultFractionDigits());
+        df.setMaximumFractionDigits(amount.getCurrency().getDefaultFractionDigits());
+
         BigDecimal number = amount.getNumber().numberValue(BigDecimal.class)
                 .setScale(amount.getCurrency().getDefaultFractionDigits(), RoundingMode.HALF_UP);
 
-        String numberFormatted = number
-                .stripTrailingZeros()
-                .toPlainString();
+        String numberFormatted = df.format(number);
+        String withSpaces = new StringBuilder(numberFormatted)
+                .insert(numberFormatted.indexOf('.') + 3, NNBSP)
+                .insert(numberFormatted.indexOf('.') + 7, NNBSP)
+                .toString();
 
-        return amount.getCurrency().getCurrencyCode() + SEPARATOR + numberFormatted;
+        return amount.getCurrency().getCurrencyCode() + SEPARATOR + withSpaces;
     }
 }

--- a/bitcoin-jsr354/bitcoin-jsr354-format/src/test/java/org/tbk/bitcoin/format/BitcoinAmountFormatProviderTest.java
+++ b/bitcoin-jsr354/bitcoin-jsr354-format/src/test/java/org/tbk/bitcoin/format/BitcoinAmountFormatProviderTest.java
@@ -34,20 +34,40 @@ class BitcoinAmountFormatProviderTest {
     void itShouldFormatBitcoinAmountCorrectly() {
         Money singleSatoshi = Money.ofMinor(bitcoinUnit, 1);
         String singleSatoshiFormatted = sut.format(singleSatoshi);
-        assertThat(singleSatoshiFormatted, is("BTC 0.00000001"));
+        assertThat(singleSatoshiFormatted, is("BTC 0.00\u202F000\u202F001"));
 
         Money singleBitcoin = Money.of(BigDecimal.ONE, bitcoinUnit);
         String singleBitcoinFormatted = sut.format(singleBitcoin);
-        assertThat(singleBitcoinFormatted, is("BTC 1"));
+        assertThat(singleBitcoinFormatted, is("BTC 1.00\u202F000\u202F000"));
+
+        Money money1 = Money.ofMinor(bitcoinUnit, 1).multiply(21_000);
+        String money1Formatted = sut.format(money1);
+        assertThat(money1Formatted, is("BTC 0.00\u202F021\u202F000"));
+
+        Money money2 = Money.of(BigDecimal.ONE, bitcoinUnit).multiply(21_000_000);
+        String money2Formatted = sut.format(money2);
+        assertThat(money2Formatted, is("BTC 21,000,000.00\u202F000\u202F000"));
     }
 
     @Test
     void itShouldParseBitcoinAmountCorrectly() {
-        MonetaryAmount singleSatoshi = sut.parse("BTC 0.00000001");
-        assertThat(singleSatoshi, is(Money.ofMinor(bitcoinUnit, 1)));
+        assertThat(sut.parse("BTC 0.00 000 001"), is(Money.ofMinor(bitcoinUnit, 1)));
+        assertThat(sut.parse("BTC 0.00 000\u202F001"), is(Money.ofMinor(bitcoinUnit, 1)));
+        assertThat(sut.parse("BTC 0.00\u202F000\u202F001"), is(Money.ofMinor(bitcoinUnit, 1)));
 
-        MonetaryAmount singleBitcoin = sut.parse("BTC 1");
-        assertThat(singleBitcoin, is(Money.of(BigDecimal.ONE, bitcoinUnit)));
+        assertThat(sut.parse("BTC 1"), is(Money.of(BigDecimal.ONE, bitcoinUnit)));
+        assertThat(sut.parse("BTC 1."), is(Money.of(BigDecimal.ONE, bitcoinUnit)));
+        assertThat(sut.parse("BTC 1.0"), is(Money.of(BigDecimal.ONE, bitcoinUnit)));
+        assertThat(sut.parse("BTC 1.000"), is(Money.of(BigDecimal.ONE, bitcoinUnit)));
+        assertThat(sut.parse("BTC 1.00 000 000"), is(Money.of(BigDecimal.ONE, bitcoinUnit)));
+        assertThat(sut.parse("BTC 1.00 000\u202F000"), is(Money.of(BigDecimal.ONE, bitcoinUnit)));
+        assertThat(sut.parse("BTC 1"), is(Money.of(BigDecimal.ONE, bitcoinUnit)));
+
+        Money money1 = Money.ofMinor(bitcoinUnit, 1).multiply(21_000);
+        assertThat(sut.parse(sut.format(money1)), is(money1));
+
+        Money money2 = Money.of(BigDecimal.ONE, bitcoinUnit).multiply(21_000_000);
+        assertThat(sut.parse(sut.format(money2)), is(money2));
     }
 
 }

--- a/changelog.md
+++ b/changelog.md
@@ -24,6 +24,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - upgrade: update sqlite from v3.42.0.0 to v3.44.1.0
 - upgrade: update jmolecules from v2022.3.0 to v2023.1.1
 
+### Fixed
+- fix: format sats with space grouping char in BitcoinAmountFormat
+
 ## [0.11.0] - 2023-09-21
 ### Breaking
 - module bitcoin-jsonrpc-client-autoconfigure: dependencies not included in anymore

--- a/examples/incubator/bitcoin-payment-request-example-application/src/main/java/org/tbk/bitcoin/example/payreq/db/migration/V1__init.java
+++ b/examples/incubator/bitcoin-payment-request-example-application/src/main/java/org/tbk/bitcoin/example/payreq/db/migration/V1__init.java
@@ -14,64 +14,73 @@ public class V1__init extends BaseJavaMigration {
     public void migrate(Context context) throws Exception {
 
         String sql1 = "create table if not exists customer_order "
-                + "(id string PRIMARY KEY, version integer, created_at integer, updated_at integer, status string)";
+                + "(id text PRIMARY KEY, version integer, created_at integer, updated_at integer, status text) "
+                + "STRICT";
 
         String sql2 = "create table if not exists customer_order_line_item "
-                + "(id string PRIMARY KEY, order_id string, position integer, name string, price string, currency_unit string, display_price string, quantity integer, "
+                + "(id text PRIMARY KEY, order_id text, position integer, name text, price text, currency_unit text, display_price text, quantity integer, "
                 + "FOREIGN KEY(order_id) REFERENCES customer_order(id)"
-                + ")";
+                + ") "
+                + "STRICT";
 
         String sql3 = "create table if not exists payment_request "
-                + "(id string PRIMARY KEY, version integer, created_at integer, updated_at integer, order_id string, dtype string, status string, valid_until integer, amount string, currency_unit string, display_price string, "
-                + "network string, " // for all btc payments (onchain, lightning, etc.)
-                + "address string, min_confirmations integer, " // for onchain payments
-                + "payment_hash string, r_hash string, " // for lightning payments
+                + "(id text PRIMARY KEY, version integer, created_at integer, updated_at integer, order_id text, dtype text, status text, valid_until integer, amount text, currency_unit text, display_price text, "
+                + "network text, " // for all btc payments (onchain, lightning, etc.)
+                + "address text, min_confirmations integer, " // for onchain payments
+                + "payment_hash text, r_hash text, " // for lightning payments
                 + "FOREIGN KEY(order_id) REFERENCES customer_order(id), "
                 + "UNIQUE(address), "
                 + "UNIQUE(r_hash) "
-                + ")";
+                + ") "
+                + "STRICT";
 
         String sql4 = "create table if not exists invoice "
-                + "(id string PRIMARY KEY, version integer, created_at integer, order_id string, comment string,"
+                + "(id text PRIMARY KEY, version integer, created_at integer, order_id text, comment text,"
                 + "FOREIGN KEY(order_id) REFERENCES customer_order(id)"
-                + ")";
+                + ") "
+                + "STRICT";
 
         String sql5 = "create table if not exists donation "
-                + "(id string PRIMARY KEY, version integer, created_at integer, order_id string, payment_request_id string, display_price string, description string, payment_url string, comment string, "
+                + "(id text PRIMARY KEY, version integer, created_at integer, order_id text, payment_request_id text, display_price text, description text, payment_url text, comment text, "
                 + "FOREIGN KEY(order_id) REFERENCES customer_order(id), "
                 + "FOREIGN KEY(payment_request_id) REFERENCES payment_request(id), "
                 + "UNIQUE(order_id), "
                 + "UNIQUE(payment_request_id)"
-                + ")";
+                + ") "
+                + "STRICT";
 
         String sql6 = "create table if not exists exchange_rate "
-                + "(id string PRIMARY KEY, created_at integer, provider_name string, rate_type string, base_currency string, term_currency string, factor string)";
+                + "(id text PRIMARY KEY, created_at integer, provider_name text, rate_type text, base_currency text, term_currency text, factor text) "
+                + "STRICT";
 
         String sql7 = "create table if not exists bitcoin_block "
-                + "(id string PRIMARY KEY, "
+                + "(id text PRIMARY KEY, "
                 + "created_at integer, "
                 + "updated_at integer, "
-                + "hash string NOT NULL, "
+                + "hash text NOT NULL, "
                 + "time integer NOT NULL,"
                 + "nonce integer NOT NULL, "
                 + "confirmations integer NOT NULL, "
                 + "size integer NOT NULL, "
                 + "height integer NOT NULL, "
                 + "version integer NOT NULL, "
-                + "previousblockhash string NOT NULL, "
-                + "nextblockhash string"
-                + ")";
+                + "previousblockhash text NOT NULL, "
+                + "nextblockhash text"
+                + ") "
+                + "STRICT";
 
         String sql8 = "create table if not exists bitcoin_chain_info "
-                + "(id string PRIMARY KEY, created_at integer, chain string, blocks integer, headers integer, "
-                + "best_block_hash string, difficulty string, verification_progress string, chain_work string, "
+                + "(id text PRIMARY KEY, created_at integer, chain text, blocks integer, headers integer, "
+                + "best_block_hash text, difficulty text, verification_progress text, chain_work text, "
                 + "UNIQUE(chain, best_block_hash) "
-                + ")";
+                + ") "
+                + "STRICT";
 
         String sql9 = "create table if not exists lnd_info "
-                + "(id string PRIMARY KEY, created_at integer, block_height integer, block_hash string, best_header_timestamp integer, "
+                + "(id text PRIMARY KEY, created_at integer, block_height integer, block_hash text, best_header_timestamp integer, "
                 + "UNIQUE(block_hash) "
-                + ")";
+                + ") "
+                + "STRICT";
 
         for (String sql : Lists.newArrayList(sql1, sql2, sql3, sql4, sql5, sql6, sql7, sql8, sql9)) {
             try (PreparedStatement statement = context.getConnection().prepareStatement(sql)) {

--- a/examples/incubator/bitcoin-payment-request-example-application/src/main/java/org/tbk/bitcoin/example/payreq/db/migration/V1__init.java
+++ b/examples/incubator/bitcoin-payment-request-example-application/src/main/java/org/tbk/bitcoin/example/payreq/db/migration/V1__init.java
@@ -12,75 +12,113 @@ public class V1__init extends BaseJavaMigration {
 
     @Override
     public void migrate(Context context) throws Exception {
-
-        String sql1 = "create table if not exists customer_order "
-                + "(id text PRIMARY KEY, version integer, created_at integer, updated_at integer, status text) "
-                + "STRICT";
-
-        String sql2 = "create table if not exists customer_order_line_item "
-                + "(id text PRIMARY KEY, order_id text, position integer, name text, price text, currency_unit text, display_price text, quantity integer, "
-                + "FOREIGN KEY(order_id) REFERENCES customer_order(id)"
-                + ") "
-                + "STRICT";
-
+        String sql1 = """
+                create table if not exists customer_order (
+                    id text PRIMARY KEY,
+                    version integer,
+                    created_at integer,
+                    updated_at integer,
+                    status text
+                ) STRICT;
+                """;
+        String sql2 = """
+                create table if not exists customer_order_line_item (
+                    id text PRIMARY KEY,
+                    order_id text,
+                    position integer,
+                    name text,
+                    price text,
+                    currency_unit text,
+                    display_price text,
+                    quantity integer,
+                    FOREIGN KEY(order_id) REFERENCES customer_order(id)
+                ) STRICT;
+                """;
         String sql3 = "create table if not exists payment_request "
-                + "(id text PRIMARY KEY, version integer, created_at integer, updated_at integer, order_id text, dtype text, status text, valid_until integer, amount text, currency_unit text, display_price text, "
-                + "network text, " // for all btc payments (onchain, lightning, etc.)
-                + "address text, min_confirmations integer, " // for onchain payments
-                + "payment_hash text, r_hash text, " // for lightning payments
-                + "FOREIGN KEY(order_id) REFERENCES customer_order(id), "
-                + "UNIQUE(address), "
-                + "UNIQUE(r_hash) "
-                + ") "
-                + "STRICT";
-
-        String sql4 = "create table if not exists invoice "
-                + "(id text PRIMARY KEY, version integer, created_at integer, order_id text, comment text,"
-                + "FOREIGN KEY(order_id) REFERENCES customer_order(id)"
-                + ") "
-                + "STRICT";
-
-        String sql5 = "create table if not exists donation "
-                + "(id text PRIMARY KEY, version integer, created_at integer, order_id text, payment_request_id text, display_price text, description text, payment_url text, comment text, "
-                + "FOREIGN KEY(order_id) REFERENCES customer_order(id), "
-                + "FOREIGN KEY(payment_request_id) REFERENCES payment_request(id), "
-                + "UNIQUE(order_id), "
-                + "UNIQUE(payment_request_id)"
-                + ") "
-                + "STRICT";
-
-        String sql6 = "create table if not exists exchange_rate "
-                + "(id text PRIMARY KEY, created_at integer, provider_name text, rate_type text, base_currency text, term_currency text, factor text) "
-                + "STRICT";
-
-        String sql7 = "create table if not exists bitcoin_block "
-                + "(id text PRIMARY KEY, "
-                + "created_at integer, "
-                + "updated_at integer, "
-                + "hash text NOT NULL, "
-                + "time integer NOT NULL,"
-                + "nonce integer NOT NULL, "
-                + "confirmations integer NOT NULL, "
-                + "size integer NOT NULL, "
-                + "height integer NOT NULL, "
-                + "version integer NOT NULL, "
-                + "previousblockhash text NOT NULL, "
-                + "nextblockhash text"
-                + ") "
-                + "STRICT";
-
-        String sql8 = "create table if not exists bitcoin_chain_info "
-                + "(id text PRIMARY KEY, created_at integer, chain text, blocks integer, headers integer, "
-                + "best_block_hash text, difficulty text, verification_progress text, chain_work text, "
-                + "UNIQUE(chain, best_block_hash) "
-                + ") "
-                + "STRICT";
-
-        String sql9 = "create table if not exists lnd_info "
-                + "(id text PRIMARY KEY, created_at integer, block_height integer, block_hash text, best_header_timestamp integer, "
-                + "UNIQUE(block_hash) "
-                + ") "
-                + "STRICT";
+                      + "(id text PRIMARY KEY, version integer, created_at integer, updated_at integer, order_id text, dtype text, status text, valid_until integer, amount text, currency_unit text, display_price text, "
+                      + "network text, " // for all btc payments (onchain, lightning, etc.)
+                      + "address text, min_confirmations integer, " // for onchain payments
+                      + "payment_hash text, r_hash text, " // for lightning payments
+                      + "FOREIGN KEY(order_id) REFERENCES customer_order(id), "
+                      + "UNIQUE(address), "
+                      + "UNIQUE(r_hash) "
+                      + ") "
+                      + "STRICT";
+        String sql4 = """
+                create table if not exists invoice (
+                    id text PRIMARY KEY,
+                    version integer,
+                    created_at integer,
+                    order_id text,
+                    comment text,
+                    FOREIGN KEY(order_id) REFERENCES customer_order(id)
+                ) STRICT;
+                """;
+        String sql5 = """
+                create table if not exists donation (
+                    id text PRIMARY KEY,
+                    version integer,
+                    created_at integer,
+                    order_id text,
+                    payment_request_id text,
+                    display_price text,
+                    description text,
+                    payment_url text,
+                    comment text,
+                    FOREIGN KEY(order_id) REFERENCES customer_order(id),
+                    FOREIGN KEY(payment_request_id) REFERENCES payment_request(id),
+                    UNIQUE(order_id),
+                    UNIQUE(payment_request_id)
+                ) STRICT;
+                """;
+        String sql6 = """
+                create table if not exists exchange_rate (
+                    id text PRIMARY KEY,
+                    created_at integer,
+                    provider_name text,
+                    rate_type text,
+                    base_currency text,
+                    term_currency text,
+                    factor text
+                ) STRICT;
+                """;
+        String sql7 = """
+                create table if not exists bitcoin_block (
+                    id text PRIMARY KEY,
+                    created_at integer,
+                    updated_at integer,
+                    hash text NOT NULL,
+                    time integer NOT NULL,
+                    nonce integer NOT NULL,
+                    confirmations integer NOT NULL,
+                    size integer NOT NULL,
+                    height integer NOT NULL,
+                    version integer NOT NULL,
+                    previousblockhash text NOT NULL,
+                    nextblockhash text
+                ) STRICT;
+                """;
+        String sql8 = """
+                create table if not exists bitcoin_chain_info (
+                    id text PRIMARY KEY,
+                    created_at integer,
+                    chain text,
+                    blocks integer,
+                    headers integer,
+                    best_block_hash text, difficulty text, verification_progress text, chain_work text,
+                    UNIQUE(chain, best_block_hash)
+                ) STRICT;
+                """;
+        String sql9 = """
+                create table if not exists lnd_info (
+                    id text PRIMARY KEY,
+                    created_at integer,
+                    block_height integer,
+                    block_hash text,
+                    best_header_timestamp integer,
+                    UNIQUE(block_hash)
+                ) STRICT;
+                """;
 
         for (String sql : Lists.newArrayList(sql1, sql2, sql3, sql4, sql5, sql6, sql7, sql8, sql9)) {
             try (PreparedStatement statement = context.getConnection().prepareStatement(sql)) {
@@ -88,5 +126,4 @@ public class V1__init extends BaseJavaMigration {
             }
         }
     }
-
 }

--- a/examples/incubator/bitcoin-payment-request-example-application/src/main/java/org/tbk/bitcoin/example/payreq/order/LineItem.java
+++ b/examples/incubator/bitcoin-payment-request-example-application/src/main/java/org/tbk/bitcoin/example/payreq/order/LineItem.java
@@ -36,7 +36,7 @@ public class LineItem implements Entity<Order, LineItem.LineItemId> {
     private Integer position;
 
     public LineItem(String name, MonetaryAmount price) {
-        this.id = LineItemId.of(UUID.randomUUID());
+        this.id = LineItemId.create();
         this.name = name;
         this.price = price.getNumber();
         this.currencyUnit = price.getCurrency();
@@ -66,7 +66,12 @@ public class LineItem implements Entity<Order, LineItem.LineItemId> {
 
     @Value(staticConstructor = "of")
     public static class LineItemId implements Identifier {
+
+        public static LineItem.LineItemId create() {
+            return LineItem.LineItemId.of(UUID.randomUUID().toString());
+        }
+
         @NonNull
-        UUID id;
+        String id;
     }
 }

--- a/examples/incubator/bitcoin-payment-request-example-application/src/main/java/org/tbk/bitcoin/example/payreq/order/LineItem.java
+++ b/examples/incubator/bitcoin-payment-request-example-application/src/main/java/org/tbk/bitcoin/example/payreq/order/LineItem.java
@@ -9,9 +9,9 @@ import lombok.Value;
 import org.javamoney.moneta.Money;
 import org.jmolecules.ddd.types.Entity;
 import org.jmolecules.ddd.types.Identifier;
+import org.tbk.bitcoin.example.payreq.common.MonetaryAmountFormats;
 
 import javax.money.CurrencyUnit;
-import javax.money.Monetary;
 import javax.money.MonetaryAmount;
 import javax.money.NumberValue;
 import java.util.UUID;
@@ -40,7 +40,7 @@ public class LineItem implements Entity<Order, LineItem.LineItemId> {
         this.name = name;
         this.price = price.getNumber();
         this.currencyUnit = price.getCurrency();
-        this.displayPrice = price.with(Monetary.getRounding(price.getCurrency())).toString();
+        this.displayPrice = MonetaryAmountFormats.bitcoin.format(price);
         this.quantity = 1;
     }
 

--- a/examples/incubator/bitcoin-payment-request-example-application/src/main/java/org/tbk/bitcoin/example/payreq/order/Order.java
+++ b/examples/incubator/bitcoin-payment-request-example-application/src/main/java/org/tbk/bitcoin/example/payreq/order/Order.java
@@ -2,10 +2,7 @@ package org.tbk.bitcoin.example.payreq.order;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.collect.ImmutableMap;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OrderColumn;
-import jakarta.persistence.Table;
-import jakarta.persistence.Version;
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.ToString;
@@ -41,6 +38,7 @@ public class Order extends AbstractAggregateRoot<Order> implements AggregateRoot
     @UpdateTimestamp
     private Instant updatedAt;
 
+    @Enumerated(EnumType.STRING)
     private Status status;
 
     @JsonIgnore

--- a/incubator/spring-lnurl/spring-lnurl-auth-example-application/src/main/java/org/tbk/lightning/lnurl/example/db/migration/V1__init.java
+++ b/incubator/spring-lnurl/spring-lnurl-auth-example-application/src/main/java/org/tbk/lightning/lnurl/example/db/migration/V1__init.java
@@ -12,30 +12,34 @@ public class V1__init extends BaseJavaMigration {
 
     @Override
     public void migrate(Context context) throws Exception {
-        String sql1 = "CREATE TABLE IF NOT EXISTS lnurl_auth_wallet_user ("
-                + "id string PRIMARY KEY, "
-                + "version integer, "
-                + "created_at integer, "
-                + "name string, "
-                + "last_successful_auth_at integer, "
-                + "account_disabled_at integer, "
-                + "account_locked_at integer, "
-                + "account_expired_at integer, "
-                + "credentials_expired_at integer"
-                + ")";
-
-        String sql2 = "CREATE TABLE IF NOT EXISTS lnurl_auth_linking_key "
-                + "(id string PRIMARY KEY, "
-                + "version integer, "
-                + "created_at integer, "
-                + "lnurl_auth_wallet_user_id string, "
-                + "linking_key string, "
-                + "least_recently_used_k1 string, "
-                + "FOREIGN KEY(lnurl_auth_wallet_user_id) REFERENCES lnurl_auth_wallet_user(id) ON DELETE CASCADE ON UPDATE CASCADE, "
-                + "UNIQUE(linking_key)"
-                + ")";
-
-        String sql3 = "CREATE INDEX IF NOT EXISTS lnurl_auth_linking_key_fk1 ON lnurl_auth_linking_key (lnurl_auth_wallet_user_id)";
+        String sql1 = """
+                CREATE TABLE IF NOT EXISTS lnurl_auth_wallet_user (
+                    id text PRIMARY KEY,
+                    version integer,
+                    created_at integer,
+                    name text,
+                    last_successful_auth_at integer,
+                    account_disabled_at integer,
+                    account_locked_at integer,
+                    account_expired_at integer,
+                    credentials_expired_at integer
+                ) STRICT;
+                """;
+        String sql2 = """
+                CREATE TABLE IF NOT EXISTS lnurl_auth_linking_key (
+                    id text PRIMARY KEY,
+                    version integer,
+                    created_at integer,
+                    lnurl_auth_wallet_user_id text,
+                    linking_key text,
+                    least_recently_used_k1 text,
+                    FOREIGN KEY(lnurl_auth_wallet_user_id) REFERENCES lnurl_auth_wallet_user(id) ON DELETE CASCADE ON UPDATE CASCADE,
+                    UNIQUE(linking_key)
+                ) STRICT;
+                """;
+        String sql3 = """
+                CREATE INDEX IF NOT EXISTS lnurl_auth_linking_key_fk1 ON lnurl_auth_linking_key (lnurl_auth_wallet_user_id);
+                """;
 
         for (String sql : Lists.newArrayList(sql1, sql2, sql3)) {
             try (PreparedStatement statement = context.getConnection().prepareStatement(sql)) {
@@ -43,5 +47,4 @@ public class V1__init extends BaseJavaMigration {
             }
         }
     }
-
 }

--- a/incubator/spring-lnurl/spring-lnurl-auth-example-application/src/main/java/org/tbk/lightning/lnurl/example/db/migration/V2__spring_session.java
+++ b/incubator/spring-lnurl/spring-lnurl-auth-example-application/src/main/java/org/tbk/lightning/lnurl/example/db/migration/V2__spring_session.java
@@ -13,30 +13,36 @@ public class V2__spring_session extends BaseJavaMigration {
     @Override
     public void migrate(Context context) throws Exception {
         // taken from "classpath:org/springframework/session/jdbc/schema-sqlite.sql"
-        String sql1 = ""
-                + "CREATE TABLE SPRING_SESSION (\n"
-                + "    PRIMARY_ID CHARACTER(36) NOT NULL,\n"
-                + "    SESSION_ID CHARACTER(36) NOT NULL,\n"
-                + "    CREATION_TIME INTEGER NOT NULL,\n"
-                + "    LAST_ACCESS_TIME INTEGER NOT NULL,\n"
-                + "    MAX_INACTIVE_INTERVAL INTEGER NOT NULL,\n"
-                + "    EXPIRY_TIME INTEGER NOT NULL,\n"
-                + "    PRINCIPAL_NAME VARCHAR(100),\n"
-                + "    CONSTRAINT SPRING_SESSION_PK PRIMARY KEY (PRIMARY_ID)\n"
-                + ");";
-
-        String sql2 = "CREATE UNIQUE INDEX SPRING_SESSION_IX1 ON SPRING_SESSION (SESSION_ID);";
-        String sql3 = "CREATE INDEX SPRING_SESSION_IX2 ON SPRING_SESSION (EXPIRY_TIME);";
-        String sql4 = "CREATE INDEX SPRING_SESSION_IX3 ON SPRING_SESSION (PRINCIPAL_NAME);";
-
-        String sql5 = ""
-                + "CREATE TABLE SPRING_SESSION_ATTRIBUTES (\n"
-                + "    SESSION_PRIMARY_ID CHAR(36) NOT NULL,\n"
-                + "    ATTRIBUTE_NAME VARCHAR(200) NOT NULL,\n"
-                + "    ATTRIBUTE_BYTES BLOB NOT NULL,\n"
-                + "    CONSTRAINT SPRING_SESSION_ATTRIBUTES_PK PRIMARY KEY (SESSION_PRIMARY_ID, ATTRIBUTE_NAME),\n"
-                + "    CONSTRAINT SPRING_SESSION_ATTRIBUTES_FK FOREIGN KEY (SESSION_PRIMARY_ID) REFERENCES SPRING_SESSION(PRIMARY_ID) ON DELETE CASCADE\n"
-                + ");";
+        String sql1 = """
+                CREATE TABLE SPRING_SESSION (
+                    PRIMARY_ID CHARACTER(36) NOT NULL,
+                    SESSION_ID CHARACTER(36) NOT NULL,
+                    CREATION_TIME INTEGER NOT NULL,
+                    LAST_ACCESS_TIME INTEGER NOT NULL,
+                    MAX_INACTIVE_INTERVAL INTEGER NOT NULL,
+                    EXPIRY_TIME INTEGER NOT NULL,
+                    PRINCIPAL_NAME VARCHAR(100),
+                    CONSTRAINT SPRING_SESSION_PK PRIMARY KEY (PRIMARY_ID)
+                );
+                """;
+        String sql2 = """
+                CREATE UNIQUE INDEX SPRING_SESSION_IX1 ON SPRING_SESSION (SESSION_ID);
+                """;
+        String sql3 = """
+                CREATE INDEX SPRING_SESSION_IX2 ON SPRING_SESSION (EXPIRY_TIME);
+                """;
+        String sql4 = """
+                CREATE INDEX SPRING_SESSION_IX3 ON SPRING_SESSION (PRINCIPAL_NAME);
+                """;
+        String sql5 = """
+                CREATE TABLE SPRING_SESSION_ATTRIBUTES (
+                    SESSION_PRIMARY_ID CHAR(36) NOT NULL,
+                    ATTRIBUTE_NAME VARCHAR(200) NOT NULL,
+                    ATTRIBUTE_BYTES BLOB NOT NULL,
+                    CONSTRAINT SPRING_SESSION_ATTRIBUTES_PK PRIMARY KEY (SESSION_PRIMARY_ID, ATTRIBUTE_NAME),
+                    CONSTRAINT SPRING_SESSION_ATTRIBUTES_FK FOREIGN KEY (SESSION_PRIMARY_ID) REFERENCES SPRING_SESSION(PRIMARY_ID) ON DELETE CASCADE
+                );
+                """;
 
         for (String sql : Lists.newArrayList(sql1, sql2, sql3, sql4, sql5)) {
             try (PreparedStatement statement = context.getConnection().prepareStatement(sql)) {
@@ -44,5 +50,4 @@ public class V2__spring_session extends BaseJavaMigration {
             }
         }
     }
-
 }


### PR DESCRIPTION
sqlite will store floating point numbers sent as string as actual real numbers with exponential notation.
Using strict should explicitely store them as string.

See also: https://www.sqlite.org/stricttables.html

[sqlitebrowser](https://github.com/sqlitebrowser/sqlitebrowser) currently errors when trying to view STRICT tables, see https://github.com/sqlitebrowser/sqlitebrowser/issues/3259#issuecomment-1485322524.