### PR TITLE
use canonical form for property conditions

### DIFF
--- a/cln-grpc-client/cln-grpc-client-autoconfigure/src/main/java/org/tbk/lightning/cln/grpc/config/ClnClientAutoConfiguration.java
+++ b/cln-grpc-client/cln-grpc-client-autoconfigure/src/main/java/org/tbk/lightning/cln/grpc/config/ClnClientAutoConfiguration.java
@@ -49,9 +49,9 @@ public class ClnClientAutoConfiguration {
     @Bean("clnRpcSslContext")
     @ConditionalOnMissingBean(name = "clnRpcSslContext")
     @ConditionalOnProperty({
-            "org.tbk.lightning.cln.grpc.caCertFilePath",
-            "org.tbk.lightning.cln.grpc.clientCertFilePath",
-            "org.tbk.lightning.cln.grpc.clientKeyFilePath"
+            "org.tbk.lightning.cln.grpc.ca-cert-file-path",
+            "org.tbk.lightning.cln.grpc.client-cert-file-path",
+            "org.tbk.lightning.cln.grpc.client-key-file-path"
     })
     @SneakyThrows
     @SuppressFBWarnings("PATH_TRAVERSAL_IN")

--- a/cln-grpc-client/readme.md
+++ b/cln-grpc-client/readme.md
@@ -20,7 +20,7 @@ implementation "io.github.theborakompanioni:cln-grpc-client-starter:${bitcoinSpr
 ```xml
 <dependency>
     <groupId>io.github.theborakompanioni</groupId>
-    <artifactId>cln-grpc-client</artifactId>
+    <artifactId>cln-grpc-client-starter</artifactId>
     <version>${bitcoinSpringBootStarter.version}</version>
 </dependency>
 ```

--- a/lnd-grpc-client/lnd-grpc-client-autoconfigure/src/main/java/org/tbk/lightning/lnd/grpc/config/LndClientAutoConfiguration.java
+++ b/lnd-grpc-client/lnd-grpc-client-autoconfigure/src/main/java/org/tbk/lightning/lnd/grpc/config/LndClientAutoConfiguration.java
@@ -62,7 +62,7 @@ public class LndClientAutoConfiguration {
     @Bean("lndRpcMacaroonContext")
     @ConditionalOnMissingBean(name = {"lndRpcMacaroonContext"})
     @ConditionalOnProperty({
-            "org.tbk.lightning.lnd.grpc.macaroonFilePath"
+            "org.tbk.lightning.lnd.grpc.macaroon-file-path"
     })
     @SneakyThrows
     @SuppressFBWarnings("PATH_TRAVERSAL_IN")
@@ -81,7 +81,7 @@ public class LndClientAutoConfiguration {
     @Bean("lndRpcSslContext")
     @ConditionalOnMissingBean(name = {"lndRpcSslContext"})
     @ConditionalOnProperty({
-            "org.tbk.lightning.lnd.grpc.certFilePath"
+            "org.tbk.lightning.lnd.grpc.cert-file-path"
     })
     @SneakyThrows
     @SuppressFBWarnings("PATH_TRAVERSAL_IN")


### PR DESCRIPTION
properties used on @ConditionalOnProperty annotations should follow the canonical (kebab-case) form:

https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/autoconfigure/condition/ConditionalOnProperty.html:

> Use the dashed notation to specify each property, that is all lower case with a "-" to separate words (e.g. my-long-property).


https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.0-Migration-Guide#relaxed-binding:

> There is no need to worry about the structure of the key in @ConditionalOnProperty: you must now use the canonical format (acme.my-property and not acme.myProperty)

In fact, with the currently used form (camel case) in the auto configuration, the starter won't work out of the box when using the kebab-case form mentioned in the readme (tested with Spring Boot 3.0.5):

https://github.com/theborakompanioni/bitcoin-spring-boot-starter/tree/devel/cln-grpc-client