### PR TITLE
feat: improve default jsonrpc cache settings

### DIFF
--- a/bitcoin-fee/bitcoin-fee-estimate-bitcoin-jsonrpc/src/integTest/java/org/tbk/bitcoin/tool/fee/jsonrpc/BitcoinJsonRpcFeeApiClientImplTest.java
+++ b/bitcoin-fee/bitcoin-fee-estimate-bitcoin-jsonrpc/src/integTest/java/org/tbk/bitcoin/tool/fee/jsonrpc/BitcoinJsonRpcFeeApiClientImplTest.java
@@ -15,7 +15,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
 @Slf4j
-
 @SpringBootTest
 @ActiveProfiles("test")
 class BitcoinJsonRpcFeeApiClientImplTest {

--- a/bitcoin-fee/bitcoin-fee-example-application/src/main/java/org/tbk/bitcoin/fee/example/BitcoinFeeExampleApplication.java
+++ b/bitcoin-fee/bitcoin-fee-example-application/src/main/java/org/tbk/bitcoin/fee/example/BitcoinFeeExampleApplication.java
@@ -17,11 +17,17 @@ import org.tbk.bitcoin.tool.fee.FeeRecommendationResponse;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Locale;
+import java.util.TimeZone;
 import java.util.stream.IntStream;
 
 @Slf4j
 @SpringBootApplication(proxyBeanMethods = false)
 public class BitcoinFeeExampleApplication {
+    static {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+        Locale.setDefault(Locale.ENGLISH);
+    }
 
     public static void main(String[] args) {
         new SpringApplicationBuilder()

--- a/bitcoin-jsonrpc-client/bitcoin-jsonrpc-client-autoconfigure/src/integTest/java/org/tbk/bitcoin/jsonrpc/config/BitcoinJsonRpcCacheAutoConfigurationIntegrationTest.java
+++ b/bitcoin-jsonrpc-client/bitcoin-jsonrpc-client-autoconfigure/src/integTest/java/org/tbk/bitcoin/jsonrpc/config/BitcoinJsonRpcCacheAutoConfigurationIntegrationTest.java
@@ -1,5 +1,6 @@
 package org.tbk.bitcoin.jsonrpc.config;
 
+import com.google.common.cache.CacheBuilderSpec;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,6 +12,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import org.tbk.bitcoin.jsonrpc.cache.*;
+import org.tbk.bitcoin.jsonrpc.config.BitcoinJsonRpcCacheAutoConfigProperties.CacheBuilderSpecOption;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -24,16 +26,24 @@ import static org.hamcrest.Matchers.notNullValue;
         "org.tbk.bitcoin.jsonrpc.rpchost=http://localhost",
         "org.tbk.bitcoin.jsonrpc.rpcport=13337",
         "org.tbk.bitcoin.jsonrpc.rpcuser=test",
-        "org.tbk.bitcoin.jsonrpc.rpcpassword=test"
+        "org.tbk.bitcoin.jsonrpc.rpcpassword=test",
+        "org.tbk.bitcoin.jsonrpc-cache.enabled=true",
+        "org.tbk.bitcoin.jsonrpc-cache.transaction.enabled=true",
+        "org.tbk.bitcoin.jsonrpc-cache.transaction.specification=maximumSize=1",
+        "org.tbk.bitcoin.jsonrpc-cache.raw-transaction-info.enabled=true",
+        "org.tbk.bitcoin.jsonrpc-cache.raw-transaction-info.specification=maximumSize=2,expireAfterAccess=30m",
+        "org.tbk.bitcoin.jsonrpc-cache.block.enabled=false",
+        "org.tbk.bitcoin.jsonrpc-cache.block.specification=maximumSize=3",
+        "org.tbk.bitcoin.jsonrpc-cache.block-info.enabled=false"
 })
 class BitcoinJsonRpcCacheAutoConfigurationIntegrationTest {
 
     @SpringBootApplication(proxyBeanMethods = false)
-    public static class BitcoinJsonRpcTestApplication {
+    public static class BitcoinJsonRpcCacheTestApplication {
 
         public static void main(String[] args) {
             new SpringApplicationBuilder()
-                    .sources(BitcoinJsonRpcTestApplication.class)
+                    .sources(BitcoinJsonRpcCacheTestApplication.class)
                     .web(WebApplicationType.NONE)
                     .run(args);
         }
@@ -41,6 +51,28 @@ class BitcoinJsonRpcCacheAutoConfigurationIntegrationTest {
 
     @Autowired
     private ApplicationContext context;
+
+    @Test
+    void propertiesAreApplied() {
+        BitcoinJsonRpcCacheAutoConfigProperties properties = context.getBean(BitcoinJsonRpcCacheAutoConfigProperties.class);
+        assertThat(properties, is(notNullValue()));
+
+        CacheBuilderSpecOption transactionOption = properties.getTransaction();
+        assertThat(transactionOption.isEnabled(), is(true));
+        assertThat(transactionOption.getCacheBuilderSpec().toParsableString(), is("maximumSize=1"));
+
+        CacheBuilderSpecOption rawTransactionInfoOption = properties.getRawTransactionInfo();
+        assertThat(rawTransactionInfoOption.isEnabled(), is(true));
+        assertThat(rawTransactionInfoOption.getCacheBuilderSpec(), is(CacheBuilderSpec.parse("expireAfterAccess=30m,maximumSize=2")));
+
+        CacheBuilderSpecOption blockOption = properties.getBlock();
+        assertThat(blockOption.isEnabled(), is(false));
+        assertThat(blockOption.getCacheBuilderSpec(), is(CacheBuilderSpec.disableCaching()));
+
+        CacheBuilderSpecOption blockInfoOption = properties.getBlockInfo();
+        assertThat(blockInfoOption.isEnabled(), is(false));
+        assertThat(blockInfoOption.getCacheBuilderSpec().toParsableString(), is("maximumSize=0"));
+    }
 
     @Test
     void beansAreCreated() {

--- a/bitcoin-jsonrpc-client/bitcoin-jsonrpc-client-autoconfigure/src/main/java/org/tbk/bitcoin/jsonrpc/config/BitcoinJsonRpcCacheAutoConfigProperties.java
+++ b/bitcoin-jsonrpc-client/bitcoin-jsonrpc-client-autoconfigure/src/main/java/org/tbk/bitcoin/jsonrpc/config/BitcoinJsonRpcCacheAutoConfigProperties.java
@@ -1,18 +1,71 @@
 package org.tbk.bitcoin.jsonrpc.config;
 
+import com.google.common.cache.CacheBuilderSpec;
 import lombok.AllArgsConstructor;
+import lombok.Data;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.bind.ConstructorBinding;
 
+import java.util.Objects;
+
 @ConfigurationProperties(
-        prefix = "org.tbk.bitcoin.jsonrpc.cache",
+        prefix = "org.tbk.bitcoin.jsonrpc-cache",
         ignoreUnknownFields = false
 )
 @Getter
 @AllArgsConstructor(onConstructor = @__(@ConstructorBinding))
 public class BitcoinJsonRpcCacheAutoConfigProperties {
+    private static final CacheBuilderSpec defaultTransactionCacheSpec = CacheBuilderSpec.parse("""
+            recordStats,maximumSize=10000,expireAfterAccess=30m
+            """);
+    private static final CacheBuilderSpec defaultRawTransactionInfoCacheSpec = CacheBuilderSpec.parse("""
+            recordStats,maximumSize=10000,expireAfterAccess=30m
+            """);
+    private static final CacheBuilderSpec defaultBlockCacheSpec = CacheBuilderSpec.parse("""
+            recordStats,maximumSize=100,expireAfterAccess=30m
+            """);
+    private static final CacheBuilderSpec defaultBlockInfoCacheSpec = CacheBuilderSpec.parse("""
+            recordStats,maximumSize=1000,expireAfterAccess=30m
+            """);
 
-    private boolean enabled;
+    private boolean enabled = true;
 
+    private CacheBuilderSpecOption transaction;
+    private CacheBuilderSpecOption rawTransactionInfo;
+    private CacheBuilderSpecOption block;
+    private CacheBuilderSpecOption blockInfo;
+
+    public CacheBuilderSpecOption getTransaction() {
+        return Objects.requireNonNullElseGet(transaction, () -> new CacheBuilderSpecOption(true, defaultTransactionCacheSpec.toParsableString()));
+    }
+
+    public CacheBuilderSpecOption getRawTransactionInfo() {
+        return Objects.requireNonNullElseGet(rawTransactionInfo, () -> new CacheBuilderSpecOption(true, defaultRawTransactionInfoCacheSpec.toParsableString()));
+
+    }
+
+    public CacheBuilderSpecOption getBlock() {
+        return Objects.requireNonNullElseGet(block, () -> new CacheBuilderSpecOption(true, defaultBlockCacheSpec.toParsableString()));
+
+    }
+
+    public CacheBuilderSpecOption getBlockInfo() {
+        return Objects.requireNonNullElseGet(blockInfo, () -> new CacheBuilderSpecOption(true, defaultBlockInfoCacheSpec.toParsableString()));
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CacheBuilderSpecOption {
+
+        boolean enabled = true;
+
+        String specification = "";
+
+        public CacheBuilderSpec getCacheBuilderSpec() {
+            return enabled && specification != null ? CacheBuilderSpec.parse(specification) : CacheBuilderSpec.disableCaching();
+        }
+    }
 }

--- a/bitcoin-jsonrpc-client/bitcoin-jsonrpc-client-autoconfigure/src/main/java/org/tbk/bitcoin/jsonrpc/config/BitcoinJsonRpcCacheAutoConfiguration.java
+++ b/bitcoin-jsonrpc-client/bitcoin-jsonrpc-client-autoconfigure/src/main/java/org/tbk/bitcoin/jsonrpc/config/BitcoinJsonRpcCacheAutoConfiguration.java
@@ -22,7 +22,6 @@ import org.springframework.context.annotation.Configuration;
 import org.tbk.bitcoin.jsonrpc.cache.*;
 
 import java.io.IOException;
-import java.time.Duration;
 
 import static java.util.Objects.requireNonNull;
 
@@ -32,7 +31,7 @@ import static java.util.Objects.requireNonNull;
         CacheFacade.class,
         BitcoinClient.class
 })
-@ConditionalOnProperty(value = "org.tbk.bitcoin.jsonrpc.cache.enabled", havingValue = "true", matchIfMissing = true)
+@ConditionalOnProperty(value = "org.tbk.bitcoin.jsonrpc-cache.enabled", havingValue = "true", matchIfMissing = true)
 @AutoConfigureAfter(BitcoinJsonRpcClientAutoConfiguration.class)
 public class BitcoinJsonRpcCacheAutoConfiguration {
 
@@ -46,10 +45,7 @@ public class BitcoinJsonRpcCacheAutoConfiguration {
     @ConditionalOnBean(BitcoinClient.class)
     @ConditionalOnMissingBean(TransactionCache.class)
     TransactionCache bitcoinJsonRpcTransactionCache(BitcoinClient bitcoinClient) {
-        LoadingCache<Sha256Hash, Transaction> cache = CacheBuilder.newBuilder()
-                .recordStats()
-                .expireAfterAccess(Duration.ofMinutes(30))
-                .maximumSize(10_000)
+        LoadingCache<Sha256Hash, Transaction> cache = CacheBuilder.from(properties.getTransaction().getCacheBuilderSpec())
                 .build(new CacheLoader<>() {
                     @Override
                     public Transaction load(Sha256Hash key) throws IOException {
@@ -63,10 +59,7 @@ public class BitcoinJsonRpcCacheAutoConfiguration {
     @ConditionalOnBean(BitcoinClient.class)
     @ConditionalOnMissingBean(RawTransactionInfoCache.class)
     RawTransactionInfoCache bitcoinJsonRpcRawTransactionInfoCache(BitcoinClient bitcoinClient) {
-        LoadingCache<Sha256Hash, RawTransactionInfo> cache = CacheBuilder.newBuilder()
-                .recordStats()
-                .expireAfterAccess(Duration.ofMinutes(30))
-                .maximumSize(10_000)
+        LoadingCache<Sha256Hash, RawTransactionInfo> cache = CacheBuilder.from(properties.getTransaction().getCacheBuilderSpec())
                 .build(new CacheLoader<>() {
                     @Override
                     public RawTransactionInfo load(Sha256Hash key) throws IOException {
@@ -80,10 +73,7 @@ public class BitcoinJsonRpcCacheAutoConfiguration {
     @ConditionalOnBean(BitcoinClient.class)
     @ConditionalOnMissingBean(BlockCache.class)
     BlockCache bitcoinJsonRpcBlockCache(BitcoinClient bitcoinClient) {
-        LoadingCache<Sha256Hash, Block> cache = CacheBuilder.newBuilder()
-                .recordStats()
-                .expireAfterAccess(Duration.ofMinutes(30))
-                .maximumSize(10_000)
+        LoadingCache<Sha256Hash, Block> cache = CacheBuilder.from(properties.getTransaction().getCacheBuilderSpec())
                 .build(new CacheLoader<>() {
                     @Override
                     public Block load(Sha256Hash key) throws IOException {
@@ -97,10 +87,7 @@ public class BitcoinJsonRpcCacheAutoConfiguration {
     @ConditionalOnBean(BitcoinClient.class)
     @ConditionalOnMissingBean(BlockInfoCache.class)
     BlockInfoCache bitcoinJsonRpcBlockInfoCache(BitcoinClient bitcoinClient) {
-        LoadingCache<Sha256Hash, BlockInfo> cache = CacheBuilder.newBuilder()
-                .recordStats()
-                .expireAfterAccess(Duration.ofMinutes(30))
-                .maximumSize(10_000)
+        LoadingCache<Sha256Hash, BlockInfo> cache = CacheBuilder.from(properties.getTransaction().getCacheBuilderSpec())
                 .build(new CacheLoader<>() {
                     @Override
                     public BlockInfo load(Sha256Hash key) throws IOException {

--- a/bitcoin-jsonrpc-client/bitcoin-jsonrpc-client-autoconfigure/src/main/java/org/tbk/bitcoin/jsonrpc/config/BitcoinJsonRpcClientAutoConfigProperties.java
+++ b/bitcoin-jsonrpc-client/bitcoin-jsonrpc-client-autoconfigure/src/main/java/org/tbk/bitcoin/jsonrpc/config/BitcoinJsonRpcClientAutoConfigProperties.java
@@ -13,6 +13,7 @@ import java.util.Objects;
 /**
  * {
  * "enabled": true,
+ * "network": "mainnet",
  * "rpchost": "0.0.0.0",
  * "rpcport": 7000,
  * "rpcuser": "myrpcuser",

--- a/bitcoin-jsonrpc-client/bitcoin-jsonrpc-client-autoconfigure/src/test/java/org/tbk/bitcoin/jsonrpc/config/BitcoinJsonRpcCacheAutoConfigurationTest.java
+++ b/bitcoin-jsonrpc-client/bitcoin-jsonrpc-client-autoconfigure/src/test/java/org/tbk/bitcoin/jsonrpc/config/BitcoinJsonRpcCacheAutoConfigurationTest.java
@@ -13,7 +13,7 @@ class BitcoinJsonRpcCacheAutoConfigurationTest {
     private final ApplicationContextRunner contextRunner = new ApplicationContextRunner();
 
     @Test
-    void noBeansAreCreatedWhenDependecyIsMissing() {
+    void noBeansAreCreatedWhenDependencyIsMissing() {
         this.contextRunner.withUserConfiguration(BitcoinJsonRpcClientAutoConfiguration.class)
                 .withPropertyValues(
                         "org.tbk.bitcoin.jsonrpc.enabled=true"

--- a/bitcoin-jsonrpc-client/bitcoin-jsonrpc-client-example-application/build.gradle
+++ b/bitcoin-jsonrpc-client/bitcoin-jsonrpc-client-example-application/build.gradle
@@ -8,4 +8,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-quartz'
+
+    developmentOnly 'org.springframework.boot:spring-boot-docker-compose'
 }

--- a/bitcoin-jsonrpc-client/bitcoin-jsonrpc-client-example-application/docker/docker-compose.yml
+++ b/bitcoin-jsonrpc-client/bitcoin-jsonrpc-client-example-application/docker/docker-compose.yml
@@ -1,0 +1,39 @@
+version: "3"
+
+services:
+  bitcoind_regtest:
+    container_name: bitcoind_regtest
+    image: polarlightning/bitcoind:25.0
+    restart: always
+    command:
+      -regtest=1
+      -server=1
+      -whitelist=0.0.0.0/0
+      -txindex=1
+      -debug=mempool
+      -dns=0
+      -dnsseed=0
+      -networkactive=0
+      -uacomment=tbkdevbitcoindregtest
+      -printpriority=1
+      -logtimemicros=1
+      -rpcuser=regtest-rpc-user
+      -rpcpassword=regtest-rpc-pass
+      -rpcbind=0.0.0.0
+      -rpcallowip=0.0.0.0/0
+      -zmqpubrawblock=tcp://0.0.0.0:28332
+      -zmqpubrawtx=tcp://0.0.0.0:28333
+      -zmqpubhashblock=tcp://0.0.0.0:28334
+      -zmqpubhashtx=tcp://0.0.0.0:28335
+    expose:
+      - "18443"
+      - "28332"
+      - "28333"
+      - "28334"
+      - "28335"
+    ports:
+      - "18443:18443"
+      - "28332:28332"
+      - "28333:28333"
+      - "28334:28334"
+      - "28335:28335"

--- a/bitcoin-jsonrpc-client/bitcoin-jsonrpc-client-example-application/src/main/java/org/tbk/bitcoin/jsonrpc/example/BitcoinJsonrpcClientExampleApplication.java
+++ b/bitcoin-jsonrpc-client/bitcoin-jsonrpc-client-example-application/src/main/java/org/tbk/bitcoin/jsonrpc/example/BitcoinJsonrpcClientExampleApplication.java
@@ -8,9 +8,16 @@ import org.springframework.boot.context.ApplicationPidFileWriter;
 import org.springframework.boot.web.context.WebServerPortFileWriter;
 import org.springframework.context.ApplicationListener;
 
+import java.util.Locale;
+import java.util.TimeZone;
+
 @Slf4j
 @SpringBootApplication(proxyBeanMethods = false)
 public class BitcoinJsonrpcClientExampleApplication {
+    static {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+        Locale.setDefault(Locale.ENGLISH);
+    }
 
     public static void main(String[] args) {
         new SpringApplicationBuilder()

--- a/bitcoin-jsonrpc-client/bitcoin-jsonrpc-client-example-application/src/main/resources/application-development.yml
+++ b/bitcoin-jsonrpc-client/bitcoin-jsonrpc-client-example-application/src/main/resources/application-development.yml
@@ -17,5 +17,3 @@ logging.config: classpath:logback-development.xml
 logging.level.org.springframework: INFO
 logging.level.org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping: TRACE
 logging.level.web: DEBUG
-
-

--- a/bitcoin-jsonrpc-client/bitcoin-jsonrpc-client-example-application/src/main/resources/application.yml
+++ b/bitcoin-jsonrpc-client/bitcoin-jsonrpc-client-example-application/src/main/resources/application.yml
@@ -18,9 +18,24 @@ logging.level.org.springframework: INFO
 logging.level.org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping: TRACE
 #logging.level.web: DEBUG
 
+spring.docker.compose:
+  enabled: true
+  file: ./docker/docker-compose.yml
+  stop.command: DOWN # DOWN clears all container data after shutdown
+
 org.tbk.bitcoin.jsonrpc:
-  network: mainnet
+  network: regtest
   rpchost: http://localhost
-  rpcport: 8332
-  rpcuser: myrpcuser
-  rpcpassword: correct horse battery staple
+  rpcport: 18443
+  rpcuser: regtest-rpc-user
+  rpcpassword: regtest-rpc-pass
+
+org.tbk.bitcoin.jsonrpc-cache:
+  transaction:
+    specification: 'recordStats,initialCapacity=1000,maximumSize=100,expireAfterAccess=2h'
+  raw-transaction-info:
+    specification: 'recordStats,initialCapacity=1000,maximumSize=100,expireAfterAccess=2h'
+  block:
+    specification: 'recordStats,initialCapacity=10,maximumSize=10,expireAfterAccess=30m'
+  block-info:
+    specification: 'recordStats,initialCapacity=100,maximumSize=50,expireAfterAccess=1h'

--- a/bitcoin-regtest/bitcoin-regtest-example-application/src/main/java/org/tbk/bitcoin/regtest/example/BitcoinRegtestExampleApplication.java
+++ b/bitcoin-regtest/bitcoin-regtest-example-application/src/main/java/org/tbk/bitcoin/regtest/example/BitcoinRegtestExampleApplication.java
@@ -7,9 +7,16 @@ import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.context.ApplicationPidFileWriter;
 import org.springframework.context.ApplicationListener;
 
+import java.util.Locale;
+import java.util.TimeZone;
+
 @Slf4j
 @SpringBootApplication(proxyBeanMethods = false)
 public class BitcoinRegtestExampleApplication {
+    static {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+        Locale.setDefault(Locale.ENGLISH);
+    }
 
     public static void main(String[] args) {
         new SpringApplicationBuilder()

--- a/bitcoin-zeromq-client/bitcoin-zeromq-client-example-application/src/main/java/org/tbk/bitcoin/zeromq/example/BitcoinZeroMqClientExampleApplication.java
+++ b/bitcoin-zeromq-client/bitcoin-zeromq-client-example-application/src/main/java/org/tbk/bitcoin/zeromq/example/BitcoinZeroMqClientExampleApplication.java
@@ -16,12 +16,18 @@ import org.tbk.bitcoin.zeromq.client.MessagePublishService;
 import reactor.core.publisher.Flux;
 
 import java.time.Duration;
+import java.util.Locale;
+import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 @Slf4j
 @SpringBootApplication(proxyBeanMethods = false)
 public class BitcoinZeroMqClientExampleApplication {
+    static {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+        Locale.setDefault(Locale.ENGLISH);
+    }
 
     public static void main(String[] args) {
         new SpringApplicationBuilder()

--- a/changelog.md
+++ b/changelog.md
@@ -10,8 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - module bitcoin-jsonrpc-client-autoconfigure: dependencies not included in anymore
 - module cln-grpc-client-autoconfigure: dependencies not included in anymore
 - module lnd-grpc-client-autoconfigure: dependencies not included in anymore
+- autoconfig property prefix of bitcoin jsonrpc cache changed from "jsonrpc.cache" to "jsonrpc-cache"
 
 ### Changes
+- improved default specs for bitcoin jsonrpc client caches
 - upgrade: update spring-boot from v3.1.0 to v3.1.1
 - upgrade: update cln-grpc-client-core from v23.5.1 to v23.5.2
 

--- a/examples/bitcoin-autodca-example-application/src/main/java/org/tbk/bitcoin/autodca/example/BitcoinAutoDcaExampleApplication.java
+++ b/examples/bitcoin-autodca-example-application/src/main/java/org/tbk/bitcoin/autodca/example/BitcoinAutoDcaExampleApplication.java
@@ -10,9 +10,16 @@ import org.springframework.boot.context.ApplicationPidFileWriter;
 import org.springframework.boot.web.context.WebServerPortFileWriter;
 import org.springframework.context.ApplicationListener;
 
+import java.util.Locale;
+import java.util.TimeZone;
+
 @Slf4j
 @SpringBootApplication(proxyBeanMethods = false)
 public class BitcoinAutoDcaExampleApplication {
+    static {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+        Locale.setDefault(Locale.ENGLISH);
+    }
     private static final String[] profiles = new String[]{"development", "local"};
 
     public static void main(String[] args) {

--- a/examples/bitcoin-exchange-rate-example-application/src/main/java/org/tbk/bitcoin/exchange/example/BitcoinExchangeRateExampleApplication.java
+++ b/examples/bitcoin-exchange-rate-example-application/src/main/java/org/tbk/bitcoin/exchange/example/BitcoinExchangeRateExampleApplication.java
@@ -17,10 +17,16 @@ import javax.money.convert.ConversionQueryBuilder;
 import javax.money.convert.ExchangeRate;
 import javax.money.convert.ExchangeRateProvider;
 import java.util.List;
+import java.util.Locale;
+import java.util.TimeZone;
 
 @Slf4j
 @SpringBootApplication(proxyBeanMethods = false)
 public class BitcoinExchangeRateExampleApplication {
+    static {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+        Locale.setDefault(Locale.ENGLISH);
+    }
 
     public static void main(String[] args) {
         new SpringApplicationBuilder()

--- a/examples/incubator/bitcoin-duckdca-example-application/src/main/java/org/tbk/bitcoin/duckdca/example/BitcoinDuckDcaExampleApplication.java
+++ b/examples/incubator/bitcoin-duckdca-example-application/src/main/java/org/tbk/bitcoin/duckdca/example/BitcoinDuckDcaExampleApplication.java
@@ -8,9 +8,16 @@ import org.springframework.boot.context.ApplicationPidFileWriter;
 import org.springframework.boot.web.context.WebServerPortFileWriter;
 import org.springframework.context.ApplicationListener;
 
+import java.util.Locale;
+import java.util.TimeZone;
+
 @Slf4j
 @SpringBootApplication(proxyBeanMethods = false)
 public class BitcoinDuckDcaExampleApplication {
+    static {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+        Locale.setDefault(Locale.ENGLISH);
+    }
 
     public static void main(String[] args) {
         new SpringApplicationBuilder()

--- a/examples/incubator/bitcoin-electrum-gateway-example-application/src/main/java/org/tbk/electrum/gateway/example/ElectrumGatewayExampleApplication.java
+++ b/examples/incubator/bitcoin-electrum-gateway-example-application/src/main/java/org/tbk/electrum/gateway/example/ElectrumGatewayExampleApplication.java
@@ -8,9 +8,16 @@ import org.springframework.boot.context.ApplicationPidFileWriter;
 import org.springframework.boot.web.context.WebServerPortFileWriter;
 import org.springframework.context.ApplicationListener;
 
+import java.util.Locale;
+import java.util.TimeZone;
+
 @Slf4j
 @SpringBootApplication(proxyBeanMethods = false)
 public class ElectrumGatewayExampleApplication {
+    static {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+        Locale.setDefault(Locale.ENGLISH);
+    }
 
     public static void main(String[] args) {
         new SpringApplicationBuilder()

--- a/examples/incubator/bitcoin-payment-request-example-application/src/main/java/org/tbk/bitcoin/example/payreq/BitcoinPaymentRequestExampleApplication.java
+++ b/examples/incubator/bitcoin-payment-request-example-application/src/main/java/org/tbk/bitcoin/example/payreq/BitcoinPaymentRequestExampleApplication.java
@@ -8,6 +8,7 @@ import org.springframework.boot.context.ApplicationPidFileWriter;
 import org.springframework.boot.web.context.WebServerPortFileWriter;
 import org.springframework.context.ApplicationListener;
 
+import java.util.Locale;
 import java.util.TimeZone;
 
 @Slf4j
@@ -15,6 +16,7 @@ import java.util.TimeZone;
 public class BitcoinPaymentRequestExampleApplication {
     static {
         TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+        Locale.setDefault(Locale.ENGLISH);
     }
 
     public static void main(String[] args) {

--- a/examples/ln-playground-example-application/src/main/java/org/tbk/lightning/playground/example/LnPlaygroundExampleApplication.java
+++ b/examples/ln-playground-example-application/src/main/java/org/tbk/lightning/playground/example/LnPlaygroundExampleApplication.java
@@ -8,9 +8,16 @@ import org.springframework.boot.context.ApplicationPidFileWriter;
 import org.springframework.boot.web.context.WebServerPortFileWriter;
 import org.springframework.context.ApplicationListener;
 
+import java.util.Locale;
+import java.util.TimeZone;
+
 @Slf4j
 @SpringBootApplication(proxyBeanMethods = false)
 public class LnPlaygroundExampleApplication {
+    static {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+        Locale.setDefault(Locale.ENGLISH);
+    }
 
     public static void main(String[] args) {
         new SpringApplicationBuilder()

--- a/incubator/spring-lnurl/spring-lnurl-auth-example-application/src/main/java/org/tbk/lightning/lnurl/example/LnurlAuthExampleApplication.java
+++ b/incubator/spring-lnurl/spring-lnurl-auth-example-application/src/main/java/org/tbk/lightning/lnurl/example/LnurlAuthExampleApplication.java
@@ -8,6 +8,7 @@ import org.springframework.boot.context.ApplicationPidFileWriter;
 import org.springframework.boot.web.context.WebServerPortFileWriter;
 import org.springframework.context.ApplicationListener;
 
+import java.util.Locale;
 import java.util.TimeZone;
 
 @Slf4j
@@ -15,6 +16,7 @@ import java.util.TimeZone;
 public class LnurlAuthExampleApplication {
     static {
         TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+        Locale.setDefault(Locale.ENGLISH);
     }
 
     public static void main(String[] args) {

--- a/spring-testcontainer/spring-testcontainer-bitcoind-example-application/src/main/java/org/tbk/spring/testcontainer/bitcoind/example/BitcoindContainerExampleApplication.java
+++ b/spring-testcontainer/spring-testcontainer-bitcoind-example-application/src/main/java/org/tbk/spring/testcontainer/bitcoind/example/BitcoindContainerExampleApplication.java
@@ -17,12 +17,18 @@ import reactor.core.publisher.Flux;
 
 import java.io.IOException;
 import java.time.Duration;
+import java.util.Locale;
+import java.util.TimeZone;
 
 import static java.util.Objects.requireNonNull;
 
 @Slf4j
 @SpringBootApplication(proxyBeanMethods = false)
 public class BitcoindContainerExampleApplication {
+    static {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+        Locale.setDefault(Locale.ENGLISH);
+    }
 
     public static void main(String[] args) {
         new SpringApplicationBuilder()

--- a/spring-testcontainer/spring-testcontainer-btc-rpc-explorer-example-application/src/main/java/org/tbk/spring/testcontainer/btcrpcexplorer/example/BtcRpcExplorerExampleApplication.java
+++ b/spring-testcontainer/spring-testcontainer-btc-rpc-explorer-example-application/src/main/java/org/tbk/spring/testcontainer/btcrpcexplorer/example/BtcRpcExplorerExampleApplication.java
@@ -9,9 +9,16 @@ import org.springframework.boot.context.ApplicationPidFileWriter;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.annotation.Bean;
 
+import java.util.Locale;
+import java.util.TimeZone;
+
 @Slf4j
 @SpringBootApplication(proxyBeanMethods = false)
 public class BtcRpcExplorerExampleApplication {
+    static {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+        Locale.setDefault(Locale.ENGLISH);
+    }
 
     public static void main(String[] args) {
         new SpringApplicationBuilder()

--- a/spring-testcontainer/spring-testcontainer-cln-example-application/src/main/java/org/tbk/spring/testcontainer/cln/example/ClnContainerExampleApplication.java
+++ b/spring-testcontainer/spring-testcontainer-cln-example-application/src/main/java/org/tbk/spring/testcontainer/cln/example/ClnContainerExampleApplication.java
@@ -17,6 +17,8 @@ import reactor.core.publisher.Flux;
 
 import java.time.Duration;
 import java.util.HexFormat;
+import java.util.Locale;
+import java.util.TimeZone;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -27,6 +29,10 @@ import static java.util.Objects.requireNonNull;
 @Slf4j
 @SpringBootApplication(proxyBeanMethods = false)
 public class ClnContainerExampleApplication {
+    static {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+        Locale.setDefault(Locale.ENGLISH);
+    }
 
     public static void main(String[] args) {
         new SpringApplicationBuilder()

--- a/spring-testcontainer/spring-testcontainer-electrum-daemon-example-application/src/main/java/org/tbk/spring/testcontainer/electrumd/example/ElectrumDaemonExampleApplication.java
+++ b/spring-testcontainer/spring-testcontainer-electrum-daemon-example-application/src/main/java/org/tbk/spring/testcontainer/electrumd/example/ElectrumDaemonExampleApplication.java
@@ -9,9 +9,16 @@ import org.springframework.boot.context.ApplicationPidFileWriter;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.annotation.Bean;
 
+import java.util.Locale;
+import java.util.TimeZone;
+
 @Slf4j
 @SpringBootApplication(proxyBeanMethods = false)
 public class ElectrumDaemonExampleApplication {
+    static {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+        Locale.setDefault(Locale.ENGLISH);
+    }
 
     public static void main(String[] args) {
         new SpringApplicationBuilder()

--- a/spring-testcontainer/spring-testcontainer-lnd-example-application/src/main/java/org/tbk/spring/testcontainer/lnd/example/LndContainerExampleApplication.java
+++ b/spring-testcontainer/spring-testcontainer-lnd-example-application/src/main/java/org/tbk/spring/testcontainer/lnd/example/LndContainerExampleApplication.java
@@ -25,12 +25,18 @@ import reactor.core.Disposable;
 import reactor.core.publisher.Flux;
 
 import java.time.Duration;
+import java.util.Locale;
+import java.util.TimeZone;
 
 import static java.util.Objects.requireNonNull;
 
 @Slf4j
 @SpringBootApplication(proxyBeanMethods = false)
 public class LndContainerExampleApplication {
+    static {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+        Locale.setDefault(Locale.ENGLISH);
+    }
 
     public static void main(String[] args) {
         new SpringApplicationBuilder()

--- a/spring-testcontainer/spring-testcontainer-tor-example-application/src/main/java/org/tbk/spring/testcontainer/tor/example/TorContainerExampleApplication.java
+++ b/spring-testcontainer/spring-testcontainer-tor-example-application/src/main/java/org/tbk/spring/testcontainer/tor/example/TorContainerExampleApplication.java
@@ -17,10 +17,16 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Profile;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+import java.util.TimeZone;
 
 @Slf4j
 @SpringBootApplication(proxyBeanMethods = false)
 public class TorContainerExampleApplication {
+    static {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+        Locale.setDefault(Locale.ENGLISH);
+    }
 
     public static void main(String[] args) {
         new SpringApplicationBuilder()


### PR DESCRIPTION
Before:
```
defaultTransactionCacheSpec := recordStats,maximumSize=10000,expireAfterAccess=30m
defaultRawTransactionInfoCacheSpec := recordStats,maximumSize=10000,expireAfterAccess=30m
defaultBlockCacheSpec := recordStats,maximumSize=10000,expireAfterAccess=30m
defaultBlockInfoCacheSpec := recordStats,maximumSize=10000,expireAfterAccess=30m
```
After:
```
defaultTransactionCacheSpec := recordStats,maximumSize=10000,expireAfterAccess=30m
defaultRawTransactionInfoCacheSpec := recordStats,maximumSize=10000,expireAfterAccess=30m
defaultBlockCacheSpec := recordStats,maximumSize=100,expireAfterAccess=30m
defaultBlockInfoCacheSpec := recordStats,maximumSize=1000,expireAfterAccess=30m
```