### PR TITLE
fix: cyclic dependency issue in spring-lnurl-auth-autoconfigure

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- fix: cyclic dependency issue in spring-lnurl-auth-autoconfigure
+
 ## [0.12.0] - 2024-01-19
 
 ### Breaking

--- a/examples/incubator/bitcoin-payment-request-example-application/src/main/resources/application-development.yml
+++ b/examples/incubator/bitcoin-payment-request-example-application/src/main/resources/application-development.yml
@@ -15,6 +15,8 @@ server.error:
 
 management.server.port: 9001
 
+spring.datasource.url: 'jdbc:sqlite:bitcoin_payment_request_example_application-dev.db?foreign_keys=true'
+
 # LOGGING
 logging.file.path: ./var/log
 logging.file.name: application-dev.log

--- a/examples/incubator/bitcoin-payment-request-example-application/src/main/resources/application.yml
+++ b/examples/incubator/bitcoin-payment-request-example-application/src/main/resources/application.yml
@@ -30,7 +30,7 @@ logging.level.org.springframework: INFO
 #logging.level.web: DEBUG
 logging.level.org.javamoney.moneta.Money: WARN
 
-spring.datasource.url: 'jdbc:sqlite:bitcoin_payment_request_example_application.db'
+spring.datasource.url: 'jdbc:sqlite:bitcoin_payment_request_example_application.db?foreign_keys=true'
 spring.datasource.driver-class-name: org.sqlite.JDBC
 spring.datasource.hikari.pool-name: SQLitePool
 spring.datasource.hikari.connection-timeout: 30000 #maximum number of milliseconds that a client will wait for a connection

--- a/incubator/spring-lnurl/spring-lnurl-auth-autoconfigure/src/main/java/org/tbk/spring/lnurl/config/K1AutoConfiguration.java
+++ b/incubator/spring-lnurl/spring-lnurl-auth-autoconfigure/src/main/java/org/tbk/spring/lnurl/config/K1AutoConfiguration.java
@@ -10,11 +10,6 @@ import org.tbk.lnurl.auth.*;
 public class K1AutoConfiguration {
 
     @Bean
-    SimpleK1Manager k1Manager(K1Factory k1Factory, K1Cache k1Cache) {
-        return new SimpleK1Manager(k1Factory, k1Cache);
-    }
-
-    @Bean
     @ConditionalOnMissingBean(K1Factory.class)
     SimpleK1Factory k1Factory() {
         return new SimpleK1Factory();
@@ -24,5 +19,10 @@ public class K1AutoConfiguration {
     @ConditionalOnMissingBean(K1Cache.class)
     InMemoryK1Cache k1Cache() {
         return new InMemoryK1Cache();
+    }
+
+    @Bean
+    SimpleK1Manager k1Manager(K1Factory k1Factory, K1Cache k1Cache) {
+        return new SimpleK1Manager(k1Factory, k1Cache);
     }
 }

--- a/incubator/spring-lnurl/spring-lnurl-auth-example-application/src/main/java/org/tbk/lightning/lnurl/example/LnurlAuthExampleApplicationConfig.java
+++ b/incubator/spring-lnurl/spring-lnurl-auth-example-application/src/main/java/org/tbk/lightning/lnurl/example/LnurlAuthExampleApplicationConfig.java
@@ -47,8 +47,7 @@ class LnurlAuthExampleApplicationConfig {
         String callbackBaseUrl = properties.getLnurlAuthBaseUrl()
                 .or(() -> applicationHiddenServiceDefinition.flatMap(this::buildOnionUrl))
                 .orElseThrow(() -> {
-                    String errorMessage = "Cannot build lnurl-auth callback base url. "
-                            + "Please enable tor or provide an `app.lnurl-auth-base-url` property. ";
+                    String errorMessage = "Cannot build lnurl-auth callback base url. Please enable tor or provide an `app.lnurl-auth-base-url` property.";
                     return new IllegalStateException(errorMessage);
                 });
 
@@ -57,11 +56,6 @@ class LnurlAuthExampleApplicationConfig {
                 .build();
 
         return new SimpleLnurlAuthFactory(callbackUrl, k1Manager);
-    }
-
-    @Bean
-    SimpleK1Manager k1Manager() {
-        return new SimpleK1Manager();
     }
 
     @Bean

--- a/incubator/spring-lnurl/spring-lnurl-auth-example-application/src/main/java/org/tbk/lightning/lnurl/example/security/LnurlAuthWalletActionEventListener.java
+++ b/incubator/spring-lnurl/spring-lnurl-auth-example-application/src/main/java/org/tbk/lightning/lnurl/example/security/LnurlAuthWalletActionEventListener.java
@@ -4,6 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationListener;
 import org.springframework.stereotype.Component;
 import org.tbk.lnurl.auth.LnurlAuth;
+import org.tbk.lnurl.auth.SignedLnurlAuth;
 import org.tbk.spring.lnurl.security.wallet.LnurlAuthWalletActionEvent;
 
 import java.net.URI;
@@ -14,8 +15,9 @@ class LnurlAuthWalletActionEventListener implements ApplicationListener<LnurlAut
 
     @Override
     public void onApplicationEvent(LnurlAuthWalletActionEvent event) {
-        URI callbackUrl = event.getLnurlAuth().toLnurl().toUri();
-        String action = event.getAction()
+        SignedLnurlAuth auth = event.getAuthentication().getAuth();
+        URI callbackUrl = auth.toLnurl().toUri();
+        String action = auth.getAction()
                 .map(LnurlAuth.Action::getValue)
                 .orElse("<empty>");
 

--- a/incubator/spring-lnurl/spring-lnurl-auth-example-application/src/main/resources/application-development.yml
+++ b/incubator/spring-lnurl/spring-lnurl-auth-example-application/src/main/resources/application-development.yml
@@ -10,7 +10,7 @@ server.compression.enabled: true
 
 management.server.port: 9001
 
-spring.datasource.url: 'jdbc:sqlite:lnurl_auth_example_application-dev.db'
+spring.datasource.url: 'jdbc:sqlite:lnurl_auth_example_application-dev.db?foreign_keys=true'
 
 # LOGGING
 logging.file.path: ./var/log

--- a/incubator/spring-lnurl/spring-lnurl-auth-example-application/src/main/resources/application.yml
+++ b/incubator/spring-lnurl/spring-lnurl-auth-example-application/src/main/resources/application.yml
@@ -9,7 +9,7 @@ server.compression.enabled: true
 
 server.servlet.session.timeout: 24h # Session timeout. If a duration suffix is not specified, seconds are used.
 
-spring.datasource.url: 'jdbc:sqlite:lnurl_auth_example_application.db'
+spring.datasource.url: 'jdbc:sqlite:lnurl_auth_example_application.db?foreign_keys=true'
 spring.datasource.driver-class-name: org.sqlite.JDBC
 spring.datasource.hikari.pool-name: SQLitePool
 spring.datasource.hikari.connection-timeout: 30000 # maximum number of milliseconds that a client will wait for a connection

--- a/incubator/spring-lnurl/spring-lnurl-auth-security/src/integTest/java/org/tbk/spring/lnurl/security/LnurlWalletAuthenticationFilterTest.java
+++ b/incubator/spring-lnurl/spring-lnurl-auth-security/src/integTest/java/org/tbk/spring/lnurl/security/LnurlWalletAuthenticationFilterTest.java
@@ -112,9 +112,9 @@ class LnurlWalletAuthenticationFilterTest {
         assertThat(authenticationSuccessEvent.getAuthentication(), instanceOf(LnurlAuthWalletToken.class));
 
         LnurlAuthWalletToken walletToken = (LnurlAuthWalletToken) authenticationSuccessEvent.getAuthentication();
-        assertThat(walletToken.getK1(), is(signedLnurlAuth.getK1()));
-        assertThat(walletToken.getSignature(), is(signedLnurlAuth.getSignature()));
-        assertThat(walletToken.getLinkingKey(), is(signedLnurlAuth.getLinkingKey()));
+        assertThat(walletToken.getAuth().getK1(), is(signedLnurlAuth.getK1()));
+        assertThat(walletToken.getAuth().getSignature(), is(signedLnurlAuth.getSignature()));
+        assertThat(walletToken.getAuth().getLinkingKey(), is(signedLnurlAuth.getLinkingKey()));
 
         // assert that an `LnurlAuthWalletActionEvent` event has been received
         LnurlAuthWalletActionEvent lnurlAuthWalletActionEvent = applicationEvents
@@ -122,8 +122,8 @@ class LnurlWalletAuthenticationFilterTest {
                 .findFirst()
                 .orElseThrow(() -> new IllegalStateException("No LnurlAuthWalletActionEvent received"));
         assertThat(lnurlAuthWalletActionEvent.getAuthentication(), is(walletToken));
-        assertThat(lnurlAuthWalletActionEvent.getAction().isEmpty(), is(true));
-        assertThat(lnurlAuthWalletActionEvent.getLnurlAuth().toLnurl().toUri().getHost(), is("localhost"));
+        assertThat(lnurlAuthWalletActionEvent.getAuthentication().getAuth().getAction().isEmpty(), is(true));
+        assertThat(lnurlAuthWalletActionEvent.getAuthentication().getAuth().toLnurl().toUri().getHost(), is("localhost"));
     }
 
     @Test
@@ -145,8 +145,8 @@ class LnurlWalletAuthenticationFilterTest {
                 .stream(LnurlAuthWalletActionEvent.class)
                 .findFirst()
                 .orElseThrow(() -> new IllegalStateException("No LnurlAuthWalletActionEvent received"));
-        assertThat(lnurlAuthWalletActionEvent.getLnurlAuth().getK1(), is(lnurlAuth.getK1()));
-        assertThat(lnurlAuthWalletActionEvent.getAction().orElse(null), is(action));
+        assertThat(lnurlAuthWalletActionEvent.getAuthentication().getAuth().getK1(), is(lnurlAuth.getK1()));
+        assertThat(lnurlAuthWalletActionEvent.getAuthentication().getAuth().getAction().orElse(null), is(action));
     }
 
     @Test
@@ -168,8 +168,8 @@ class LnurlWalletAuthenticationFilterTest {
                 .stream(LnurlAuthWalletActionEvent.class)
                 .findFirst()
                 .orElseThrow(() -> new IllegalStateException("No LnurlAuthWalletActionEvent received"));
-        assertThat(lnurlAuthWalletActionEvent.getLnurlAuth().getK1(), is(lnurlAuth.getK1()));
-        assertThat(lnurlAuthWalletActionEvent.getLnurlAuth().toLnurl().toUri().getHost(), is(forwardedHost));
+        assertThat(lnurlAuthWalletActionEvent.getAuthentication().getAuth().getK1(), is(lnurlAuth.getK1()));
+        assertThat(lnurlAuthWalletActionEvent.getAuthentication().getAuth().toLnurl().toUri().getHost(), is(forwardedHost));
     }
 
     @Test
@@ -180,6 +180,7 @@ class LnurlWalletAuthenticationFilterTest {
         SignedLnurlAuth signedLnurlAuth = testWallet.authorize(lnurlAuth);
 
         mockMvc.perform(get(loginUri)
+                        .queryParam(LnurlAuth.LNURL_AUTH_TAG_KEY, LnurlAuth.LNURL_AUTH_TAG_PARAM_VALUE)
                         .queryParam(LnurlAuth.LNURL_AUTH_K1_KEY, "00".repeat(32))
                         .queryParam(SignedLnurlAuth.LNURL_AUTH_SIG_KEY, signedLnurlAuth.getSignature().toHex())
                         .queryParam(SignedLnurlAuth.LNURL_AUTH_KEY_KEY, signedLnurlAuth.getLinkingKey().toHex()))
@@ -197,9 +198,9 @@ class LnurlWalletAuthenticationFilterTest {
         assertThat(badCredentialsEvent.getAuthentication(), instanceOf(LnurlAuthWalletToken.class));
 
         LnurlAuthWalletToken walletToken = (LnurlAuthWalletToken) badCredentialsEvent.getAuthentication();
-        assertThat(walletToken.getK1().toHex(), is("00".repeat(32)));
-        assertThat(walletToken.getSignature(), is(signedLnurlAuth.getSignature()));
-        assertThat(walletToken.getLinkingKey(), is(signedLnurlAuth.getLinkingKey()));
+        assertThat(walletToken.getAuth().getK1().toHex(), is("00".repeat(32)));
+        assertThat(walletToken.getAuth().getSignature(), is(signedLnurlAuth.getSignature()));
+        assertThat(walletToken.getAuth().getLinkingKey(), is(signedLnurlAuth.getLinkingKey()));
     }
 
     @Test
@@ -213,6 +214,7 @@ class LnurlWalletAuthenticationFilterTest {
         SignedLnurlAuth signedLnurlAuth = testWallet.authorize(lnurlAuth);
 
         mockMvc.perform(get(loginUri)
+                        .queryParam(LnurlAuth.LNURL_AUTH_TAG_KEY, LnurlAuth.LNURL_AUTH_TAG_PARAM_VALUE)
                         .queryParam(LnurlAuth.LNURL_AUTH_K1_KEY, realK1.toHex())
                         .queryParam(SignedLnurlAuth.LNURL_AUTH_SIG_KEY, signedLnurlAuth.getSignature().toHex())
                         .queryParam(SignedLnurlAuth.LNURL_AUTH_KEY_KEY, signedLnurlAuth.getLinkingKey().toHex()))
@@ -230,9 +232,9 @@ class LnurlWalletAuthenticationFilterTest {
         assertThat(badCredentialsEvent.getAuthentication(), instanceOf(LnurlAuthWalletToken.class));
 
         LnurlAuthWalletToken walletToken = (LnurlAuthWalletToken) badCredentialsEvent.getAuthentication();
-        assertThat(walletToken.getK1(), is(realK1));
-        assertThat(walletToken.getSignature(), is(signedLnurlAuth.getSignature()));
-        assertThat(walletToken.getLinkingKey(), is(signedLnurlAuth.getLinkingKey()));
+        assertThat(walletToken.getAuth().getK1(), is(realK1));
+        assertThat(walletToken.getAuth().getSignature(), is(signedLnurlAuth.getSignature()));
+        assertThat(walletToken.getAuth().getLinkingKey(), is(signedLnurlAuth.getLinkingKey()));
     }
 
     @Test
@@ -246,6 +248,7 @@ class LnurlWalletAuthenticationFilterTest {
         String invalidKeyHex = signedLnurlAuth.getLinkingKey().toHex().replaceAll("[0-9a-fA-F]", "0");
 
         mockMvc.perform(get(loginUri)
+                        .queryParam(LnurlAuth.LNURL_AUTH_TAG_KEY, LnurlAuth.LNURL_AUTH_TAG_PARAM_VALUE)
                         .queryParam(LnurlAuth.LNURL_AUTH_K1_KEY, signedLnurlAuth.getK1().toHex())
                         .queryParam(SignedLnurlAuth.LNURL_AUTH_SIG_KEY, signedLnurlAuth.getSignature().toHex())
                         .queryParam(SignedLnurlAuth.LNURL_AUTH_KEY_KEY, invalidKeyHex))
@@ -280,6 +283,7 @@ class LnurlWalletAuthenticationFilterTest {
         LinkingKey mismatchingKey = SimpleLnurlWallet.fromSeed(Hex.decode("00".repeat(256))).deriveLinkingPublicKey(loginUri);
 
         mockMvc.perform(get(loginUri)
+                        .queryParam(LnurlAuth.LNURL_AUTH_TAG_KEY, LnurlAuth.LNURL_AUTH_TAG_PARAM_VALUE)
                         .queryParam(LnurlAuth.LNURL_AUTH_K1_KEY, signedLnurlAuth.getK1().toHex())
                         .queryParam(SignedLnurlAuth.LNURL_AUTH_SIG_KEY, signedLnurlAuth.getSignature().toHex())
                         .queryParam(SignedLnurlAuth.LNURL_AUTH_KEY_KEY, mismatchingKey.toHex()))
@@ -297,8 +301,74 @@ class LnurlWalletAuthenticationFilterTest {
         assertThat(badCredentialsEvent.getAuthentication(), instanceOf(LnurlAuthWalletToken.class));
 
         LnurlAuthWalletToken walletToken = (LnurlAuthWalletToken) badCredentialsEvent.getAuthentication();
-        assertThat(walletToken.getK1(), is(signedLnurlAuth.getK1()));
-        assertThat(walletToken.getSignature(), is(signedLnurlAuth.getSignature()));
-        assertThat(walletToken.getLinkingKey(), is(mismatchingKey));
+        assertThat(walletToken.getAuth().getK1(), is(signedLnurlAuth.getK1()));
+        assertThat(walletToken.getAuth().getSignature(), is(signedLnurlAuth.getSignature()));
+        assertThat(walletToken.getAuth().getLinkingKey(), is(mismatchingKey));
+    }
+
+    @Test
+    void walletLoginMissingTagParam() throws Exception {
+        URI loginUri = URI.create("https://localhost" + LnurlAuthConfigurer.defaultWalletLoginUrl());
+
+        LnurlAuth lnurlAuth = SimpleLnurlAuth.create(loginUri, k1Manager.create());
+
+        SignedLnurlAuth signedLnurlAuth = testWallet.authorize(lnurlAuth);
+
+        mockMvc.perform(get(loginUri)
+                        // Notice the missing "tag" query param (which must have value "login")
+                        .queryParam(LnurlAuth.LNURL_AUTH_K1_KEY, signedLnurlAuth.getK1().toHex())
+                        .queryParam(SignedLnurlAuth.LNURL_AUTH_SIG_KEY, signedLnurlAuth.getSignature().toHex())
+                        .queryParam(SignedLnurlAuth.LNURL_AUTH_KEY_KEY, signedLnurlAuth.getLinkingKey().toHex()))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.status", is("ERROR")))
+                .andExpect(jsonPath("$.reason", is("Request could not be authenticated.")));
+
+        // generates no `AuthorizationFailureEvent` as success/failure events are published by an `AuthenticationManager`
+        // which will not even be invoked for invalid requests in the first place.
+        // in this case the "tag" param is missing.
+        assertThat("no AuthorizationFailureEvent received", applicationEvents
+                .stream(AbstractAuthenticationFailureEvent.class)
+                .count(), is(0L));
+
+        assertThat("no AuthenticationSuccessEvent received", applicationEvents
+                .stream(AuthenticationSuccessEvent.class)
+                .count(), is(0L));
+
+        assertThat("no LnurlAuthWalletActionEvent received", applicationEvents
+                .stream(LnurlAuthWalletActionEvent.class)
+                .count(), is(0L));
+    }
+
+    @Test
+    void walletLoginInvalidTagParam() throws Exception {
+        URI loginUri = URI.create("https://localhost" + LnurlAuthConfigurer.defaultWalletLoginUrl());
+
+        LnurlAuth lnurlAuth = SimpleLnurlAuth.create(loginUri, k1Manager.create());
+
+        SignedLnurlAuth signedLnurlAuth = testWallet.authorize(lnurlAuth);
+
+        mockMvc.perform(get(loginUri)
+                        .queryParam(LnurlAuth.LNURL_AUTH_TAG_KEY, "some-invalid-value")
+                        .queryParam(LnurlAuth.LNURL_AUTH_K1_KEY, signedLnurlAuth.getK1().toHex())
+                        .queryParam(SignedLnurlAuth.LNURL_AUTH_SIG_KEY, signedLnurlAuth.getSignature().toHex())
+                        .queryParam(SignedLnurlAuth.LNURL_AUTH_KEY_KEY, signedLnurlAuth.getLinkingKey().toHex()))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.status", is("ERROR")))
+                .andExpect(jsonPath("$.reason", is("Request could not be authenticated.")));
+
+        // generates no `AuthorizationFailureEvent` as success/failure events are published by an `AuthenticationManager`
+        // which will not even be invoked for invalid requests in the first place.
+        // in this case the "tag" param is invalid.
+        assertThat("no AuthorizationFailureEvent received", applicationEvents
+                .stream(AbstractAuthenticationFailureEvent.class)
+                .count(), is(0L));
+
+        assertThat("no AuthenticationSuccessEvent received", applicationEvents
+                .stream(AuthenticationSuccessEvent.class)
+                .count(), is(0L));
+
+        assertThat("no LnurlAuthWalletActionEvent received", applicationEvents
+                .stream(LnurlAuthWalletActionEvent.class)
+                .count(), is(0L));
     }
 }

--- a/incubator/spring-lnurl/spring-lnurl-auth-security/src/main/java/org/tbk/spring/lnurl/security/AbstractTokenAuthenticationProvider.java
+++ b/incubator/spring-lnurl/spring-lnurl-auth-security/src/main/java/org/tbk/spring/lnurl/security/AbstractTokenAuthenticationProvider.java
@@ -10,6 +10,8 @@ import org.springframework.security.core.userdetails.UserDetailsChecker;
 import org.springframework.util.Assert;
 import org.tbk.lnurl.auth.LinkingKey;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * Best parts copied from {@link AbstractUserDetailsAuthenticationProvider}
  * and applied to lnurl-auth token authentication.
@@ -46,6 +48,6 @@ public abstract class AbstractTokenAuthenticationProvider implements Authenticat
     }
 
     public void setAuthenticationChecks(UserDetailsChecker authenticationChecks) {
-        this.authenticationChecks = authenticationChecks;
+        this.authenticationChecks = requireNonNull(authenticationChecks);
     }
 }

--- a/incubator/spring-lnurl/spring-lnurl-auth-security/src/main/java/org/tbk/spring/lnurl/security/session/LnurlAuthSessionAuthenticationFilter.java
+++ b/incubator/spring-lnurl/spring-lnurl-auth-security/src/main/java/org/tbk/spring/lnurl/security/session/LnurlAuthSessionAuthenticationFilter.java
@@ -22,8 +22,7 @@ import java.util.Optional;
 @Slf4j
 public class LnurlAuthSessionAuthenticationFilter extends AbstractAuthenticationProcessingFilter {
     @FunctionalInterface
-    public
-    interface SuccessHandlerCustomizer {
+    public interface SuccessHandlerCustomizer {
         void customize(LnurlAuthSessionAuthenticationSuccessHandler successHandler);
     }
 

--- a/incubator/spring-lnurl/spring-lnurl-auth-security/src/main/java/org/tbk/spring/lnurl/security/wallet/LnurlAuthWalletActionEvent.java
+++ b/incubator/spring-lnurl/spring-lnurl-auth-security/src/main/java/org/tbk/spring/lnurl/security/wallet/LnurlAuthWalletActionEvent.java
@@ -2,7 +2,6 @@ package org.tbk.spring.lnurl.security.wallet;
 
 import org.springframework.context.ApplicationEvent;
 import org.tbk.lnurl.auth.LnurlAuth;
-import org.tbk.lnurl.auth.SignedLnurlAuth;
 
 import java.util.Optional;
 
@@ -15,23 +14,29 @@ import static java.util.Objects.requireNonNull;
 public final class LnurlAuthWalletActionEvent extends ApplicationEvent {
 
     private final LnurlAuthWalletToken authentication;
-    private final SignedLnurlAuth lnurlAuth;
 
-    LnurlAuthWalletActionEvent(Object source, LnurlAuthWalletToken authentication, SignedLnurlAuth lnurlAuth) {
+    LnurlAuthWalletActionEvent(Object source, LnurlAuthWalletToken authentication) {
         super(source);
         this.authentication = requireNonNull(authentication);
-        this.lnurlAuth = requireNonNull(lnurlAuth);
     }
 
     public LnurlAuthWalletToken getAuthentication() {
         return authentication;
     }
 
+    /**
+     * @deprecated Use {@link #getAuthentication()} instead
+     */
+    @Deprecated(since = "0.13.0", forRemoval = true)
     public LnurlAuth getLnurlAuth() {
-        return lnurlAuth;
+        return authentication.getAuth();
     }
 
+    /**
+     * @deprecated Use {@link #getAuthentication()} instead
+     */
+    @Deprecated(since = "0.13.0", forRemoval = true)
     public Optional<LnurlAuth.Action> getAction() {
-        return lnurlAuth.getAction();
+        return getLnurlAuth().getAction();
     }
 }

--- a/incubator/spring-lnurl/spring-lnurl-auth-security/src/main/java/org/tbk/spring/lnurl/security/wallet/LnurlAuthWalletAuthenticationFilter.java
+++ b/incubator/spring-lnurl/spring-lnurl-auth-security/src/main/java/org/tbk/spring/lnurl/security/wallet/LnurlAuthWalletAuthenticationFilter.java
@@ -28,14 +28,17 @@ public class LnurlAuthWalletAuthenticationFilter extends AbstractAuthenticationP
     private static final LnurlAuthWalletAuthenticationFailureHandler failureHandler = new LnurlAuthWalletAuthenticationFailureHandler();
     private static final LnurlAuthWalletAuthenticationSuccessHandler successHandler = new LnurlAuthWalletAuthenticationSuccessHandler();
 
-    private static final String successBody = "{\n"
-                                              + "  \"status\": \"OK\"\n"
-                                              + "}";
-
-    private static final String errorBody = "{\n"
-                                            + "  \"status\": \"ERROR\",\n"
-                                            + "  \"reason\": \"Request could not be authenticated.\"\n"
-                                            + "}";
+    private static final String successBody = """
+                                              {
+                                                "status": "OK"
+                                              }
+                                              """;
+    private static final String errorBody = """
+                                            {
+                                              "status": "ERROR",
+                                              "reason": "Request could not be authenticated."
+                                            }
+                                            """;
 
     public LnurlAuthWalletAuthenticationFilter(String pathRequestPattern) {
         this(new AntPathRequestMatcher(pathRequestPattern, HttpMethod.GET.name()));

--- a/incubator/spring-lnurl/spring-lnurl-auth-security/src/main/java/org/tbk/spring/lnurl/security/wallet/LnurlAuthWalletAuthenticationFilter.java
+++ b/incubator/spring-lnurl/spring-lnurl-auth-security/src/main/java/org/tbk/spring/lnurl/security/wallet/LnurlAuthWalletAuthenticationFilter.java
@@ -29,16 +29,16 @@ public class LnurlAuthWalletAuthenticationFilter extends AbstractAuthenticationP
     private static final LnurlAuthWalletAuthenticationSuccessHandler successHandler = new LnurlAuthWalletAuthenticationSuccessHandler();
 
     private static final String successBody = """
-                                              {
-                                                "status": "OK"
-                                              }
-                                              """;
+            {
+              "status": "OK"
+            }
+            """;
     private static final String errorBody = """
-                                            {
-                                              "status": "ERROR",
-                                              "reason": "Request could not be authenticated."
-                                            }
-                                            """;
+            {
+              "status": "ERROR",
+              "reason": "Request could not be authenticated."
+            }
+            """;
 
     public LnurlAuthWalletAuthenticationFilter(String pathRequestPattern) {
         this(new AntPathRequestMatcher(pathRequestPattern, HttpMethod.GET.name()));

--- a/incubator/spring-lnurl/spring-lnurl-auth-security/src/main/java/org/tbk/spring/lnurl/security/wallet/LnurlAuthWalletToken.java
+++ b/incubator/spring-lnurl/spring-lnurl-auth-security/src/main/java/org/tbk/spring/lnurl/security/wallet/LnurlAuthWalletToken.java
@@ -7,6 +7,7 @@ import org.springframework.util.Assert;
 import org.tbk.lnurl.auth.K1;
 import org.tbk.lnurl.auth.LinkingKey;
 import org.tbk.lnurl.auth.Signature;
+import org.tbk.lnurl.auth.SignedLnurlAuth;
 
 import java.io.Serial;
 import java.util.Collection;
@@ -16,31 +17,20 @@ import static java.util.Objects.requireNonNull;
 public final class LnurlAuthWalletToken extends AbstractAuthenticationToken {
 
     @Serial
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 2L;
 
     @Getter
-    private final K1 k1;
+    private final SignedLnurlAuth auth;
 
-    @Getter
-    private final Signature signature;
-
-    @Getter
-    private final LinkingKey linkingKey;
-
-    LnurlAuthWalletToken(K1 k1, Signature signature, LinkingKey linkingKey) {
+    LnurlAuthWalletToken(SignedLnurlAuth auth) {
         super(null);
-        this.k1 = requireNonNull(k1);
-        this.signature = requireNonNull(signature);
-        this.linkingKey = requireNonNull(linkingKey);
+        this.auth = requireNonNull(auth);
         setAuthenticated(false);
     }
 
-    LnurlAuthWalletToken(K1 k1, Signature signature, LinkingKey linkingKey,
-                         Collection<? extends GrantedAuthority> authorities) {
+    LnurlAuthWalletToken(SignedLnurlAuth auth, Collection<? extends GrantedAuthority> authorities) {
         super(authorities);
-        this.k1 = requireNonNull(k1);
-        this.signature = requireNonNull(signature);
-        this.linkingKey = requireNonNull(linkingKey);
+        this.auth = requireNonNull(auth);
         super.setAuthenticated(true); // must use super, as we override
     }
 
@@ -51,12 +41,36 @@ public final class LnurlAuthWalletToken extends AbstractAuthenticationToken {
 
     @Override
     public Object getPrincipal() {
-        return this.linkingKey.toHex();
+        return this.getAuth().getLinkingKey().toHex();
     }
 
     @Override
     public void setAuthenticated(boolean isAuthenticated) throws IllegalArgumentException {
         Assert.isTrue(!isAuthenticated, "Cannot set this token to trusted - use constructor which takes a GrantedAuthority list instead");
         super.setAuthenticated(false);
+    }
+
+    /**
+     * @deprecated Use {@link #getAuth()} instead
+     */
+    @Deprecated(since = "0.13.0", forRemoval = true)
+    public K1 getK1() {
+        return auth.getK1();
+    }
+
+    /**
+     * @deprecated Use {@link #getAuth()} instead
+     */
+    @Deprecated(since = "0.13.0", forRemoval = true)
+    public Signature getSignature() {
+        return auth.getSignature();
+    }
+
+    /**
+     * @deprecated Use {@link #getAuth()} instead
+     */
+    @Deprecated(since = "0.13.0", forRemoval = true)
+    public LinkingKey getLinkingKey() {
+        return auth.getLinkingKey();
     }
 }

--- a/incubator/spring-lnurl/spring-lnurl-auth-simple/src/main/java/org/tbk/lnurl/auth/InMemoryK1Cache.java
+++ b/incubator/spring-lnurl/spring-lnurl-auth-simple/src/main/java/org/tbk/lnurl/auth/InMemoryK1Cache.java
@@ -3,7 +3,6 @@ package org.tbk.lnurl.auth;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.RemovalListener;
-import com.google.common.cache.RemovalNotification;
 import lombok.extern.slf4j.Slf4j;
 
 import java.time.Duration;

--- a/incubator/spring-lnurl/spring-lnurl-auth-simple/src/main/java/org/tbk/lnurl/auth/InMemoryLnurlAuthPairingService.java
+++ b/incubator/spring-lnurl/spring-lnurl-auth-simple/src/main/java/org/tbk/lnurl/auth/InMemoryLnurlAuthPairingService.java
@@ -3,7 +3,6 @@ package org.tbk.lnurl.auth;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.RemovalListener;
-import com.google.common.cache.RemovalNotification;
 import lombok.extern.slf4j.Slf4j;
 
 import java.time.Duration;


### PR DESCRIPTION
Resolves #110.

Fixes a cyclic dependency issue in `K1AutoConfiguration`.

Also deprecates getter methods in `LnurlAuthWalletToken`.
Use the `getAuth()` method to get access to these properties.