### PR TITLE
Make network and rpcport configurable rather than hardcoding them

### DIFF
--- a/examples/incubator/bitcoin-payment-request-example-application/src/main/resources/application.yml
+++ b/examples/incubator/bitcoin-payment-request-example-application/src/main/resources/application.yml
@@ -64,8 +64,10 @@ org.tbk.lightning.lnd.grpc:
 
 org.tbk.spring.testcontainer.bitcoind:
   enabled: true
+  network: regtest
   rpcuser: myoneandonlyrpcuser
   rpcpassword: correcthorsebatterystaple123
+  rpcport: 18443
   exposed-ports:
     - 28332
     - 28333
@@ -96,7 +98,7 @@ org.tbk.spring.testcontainer.bitcoind:
 org.tbk.spring.testcontainer.electrumx:
   enabled: true # disable if you do not need this functionality
   rpchost: localhost
-  rpcport: 18443
+  rpcport: ${org.tbk.spring.testcontainer.bitcoind.rpcport}
   rpcuser: ${org.tbk.spring.testcontainer.bitcoind.rpcuser}
   rpcpass: ${org.tbk.spring.testcontainer.bitcoind.rpcpassword}
   environment:
@@ -120,9 +122,9 @@ org.tbk.bitcoin.regtest:
       max-duration: PT120S
 
 org.tbk.bitcoin.jsonrpc:
-  network: regtest
+  network: ${org.tbk.spring.testcontainer.bitcoind.network}
   rpchost: http://localhost
-  rpcport: 18443
+  rpcport: ${org.tbk.spring.testcontainer.bitcoind.rpcport}
   rpcuser: ${org.tbk.spring.testcontainer.bitcoind.rpcuser}
   rpcpassword: ${org.tbk.spring.testcontainer.bitcoind.rpcpassword}
 

--- a/spring-testcontainer/spring-testcontainer-bitcoind-starter/src/main/java/org/tbk/spring/testcontainer/bitcoind/config/BitcoindContainerAutoConfiguration.java
+++ b/spring-testcontainer/spring-testcontainer-bitcoind-starter/src/main/java/org/tbk/spring/testcontainer/bitcoind/config/BitcoindContainerAutoConfiguration.java
@@ -61,29 +61,20 @@ public class BitcoindContainerAutoConfiguration {
     BitcoindContainer<?> bitcoindContainer() {
         List<String> commands = buildCommandList();
 
-        // TODO: expose ports specified via auto configuration properties
-//        List<Integer> hardcodedStandardPorts = ImmutableList.<Integer>builder()
-//                .addAll(this.properties.getChain() == Chain.mainnet ? Lists.newArrayList(8332, 8333) : Collections.emptyList())
-//                .addAll(this.properties.getChain() == Chain.testnet ? Lists.newArrayList(18332, 18333) : Collections.emptyList())
-//                .addAll(this.properties.getChain() == Chain.regtest ? Lists.newArrayList(18443, 18444) : Collections.emptyList())
-//                .build();
-
         log.debug("Chain: {}", this.properties.getChain().toString());
-        log.debug("RpcPort: {}", this.properties.getRpcport().get());
-        log.debug("Network: {}", this.properties.getNetwork().get());
+        log.debug("RpcPort: {}", this.properties.getRpcport());
+        log.debug("P2Pport: {}", this.properties.getP2pport());
+        log.debug("Network: {}", this.properties.getNetwork());
         List<Integer> exposedPorts = ImmutableList.<Integer>builder()
-//                .addAll(hardcodedStandardPorts)
-        		.add(this.properties.getRpcport().get())
+        		.add(this.properties.getRpcport())
+        		.add(this.properties.getP2pport())
                 .addAll(this.properties.getExposedPorts())
                 .build();
 
         // only wait for rpc ports - p2p ports might be disabled (networkactive=0); zeromq ports won't work (we can live with that for now)
         CustomHostPortWaitStrategy waitStrategy = CustomHostPortWaitStrategy.builder()
                 .ports(ImmutableList.<Integer>builder()
-//                        .addAll(this.properties.getChain() == Chain.mainnet ? Lists.newArrayList(8332) : Collections.emptyList())
-//                        .addAll(this.properties.getChain() == Chain.testnet ? Lists.newArrayList(18332) : Collections.emptyList())
-//                        .addAll(this.properties.getChain() == Chain.regtest ? Lists.newArrayList(18443) : Collections.emptyList())
-                		.add(this.properties.getRpcport().get())
+                		.add(this.properties.getRpcport())
                         .build())
                 .build();
 

--- a/spring-testcontainer/spring-testcontainer-bitcoind-starter/src/main/java/org/tbk/spring/testcontainer/bitcoind/config/BitcoindContainerAutoConfiguration.java
+++ b/spring-testcontainer/spring-testcontainer-bitcoind-starter/src/main/java/org/tbk/spring/testcontainer/bitcoind/config/BitcoindContainerAutoConfiguration.java
@@ -62,23 +62,28 @@ public class BitcoindContainerAutoConfiguration {
         List<String> commands = buildCommandList();
 
         // TODO: expose ports specified via auto configuration properties
-        List<Integer> hardcodedStandardPorts = ImmutableList.<Integer>builder()
-                .addAll(this.properties.getChain() == Chain.mainnet ? Lists.newArrayList(8332, 8333) : Collections.emptyList())
-                .addAll(this.properties.getChain() == Chain.testnet ? Lists.newArrayList(18332, 18333) : Collections.emptyList())
-                .addAll(this.properties.getChain() == Chain.regtest ? Lists.newArrayList(18443, 18444) : Collections.emptyList())
-                .build();
+//        List<Integer> hardcodedStandardPorts = ImmutableList.<Integer>builder()
+//                .addAll(this.properties.getChain() == Chain.mainnet ? Lists.newArrayList(8332, 8333) : Collections.emptyList())
+//                .addAll(this.properties.getChain() == Chain.testnet ? Lists.newArrayList(18332, 18333) : Collections.emptyList())
+//                .addAll(this.properties.getChain() == Chain.regtest ? Lists.newArrayList(18443, 18444) : Collections.emptyList())
+//                .build();
 
+        log.debug("Chain: {}", this.properties.getChain().toString());
+        log.debug("RpcPort: {}", this.properties.getRpcport().get());
+        log.debug("Network: {}", this.properties.getNetwork().get());
         List<Integer> exposedPorts = ImmutableList.<Integer>builder()
-                .addAll(hardcodedStandardPorts)
+//                .addAll(hardcodedStandardPorts)
+        		.add(this.properties.getRpcport().get())
                 .addAll(this.properties.getExposedPorts())
                 .build();
 
         // only wait for rpc ports - p2p ports might be disabled (networkactive=0); zeromq ports won't work (we can live with that for now)
         CustomHostPortWaitStrategy waitStrategy = CustomHostPortWaitStrategy.builder()
                 .ports(ImmutableList.<Integer>builder()
-                        .addAll(this.properties.getChain() == Chain.mainnet ? Lists.newArrayList(8332) : Collections.emptyList())
-                        .addAll(this.properties.getChain() == Chain.testnet ? Lists.newArrayList(18332) : Collections.emptyList())
-                        .addAll(this.properties.getChain() == Chain.regtest ? Lists.newArrayList(18443) : Collections.emptyList())
+//                        .addAll(this.properties.getChain() == Chain.mainnet ? Lists.newArrayList(8332) : Collections.emptyList())
+//                        .addAll(this.properties.getChain() == Chain.testnet ? Lists.newArrayList(18332) : Collections.emptyList())
+//                        .addAll(this.properties.getChain() == Chain.regtest ? Lists.newArrayList(18443) : Collections.emptyList())
+                		.add(this.properties.getRpcport().get())
                         .build())
                 .build();
 

--- a/spring-testcontainer/spring-testcontainer-bitcoind-starter/src/main/java/org/tbk/spring/testcontainer/bitcoind/config/BitcoindContainerAutoConfiguration.java
+++ b/spring-testcontainer/spring-testcontainer-bitcoind-starter/src/main/java/org/tbk/spring/testcontainer/bitcoind/config/BitcoindContainerAutoConfiguration.java
@@ -60,7 +60,7 @@ public class BitcoindContainerAutoConfiguration {
 
         List<Integer> exposedPorts = ImmutableList.<Integer>builder()
                 .add(this.properties.getRpcport())
-                .add(this.properties.getP2pport())
+                .add(this.properties.getPort())
                 .addAll(this.properties.getExposedPorts())
                 .build();
 
@@ -97,9 +97,9 @@ public class BitcoindContainerAutoConfiguration {
 
     private List<String> buildCommandList() {
         ImmutableList.Builder<String> requiredCommandsBuilder = ImmutableList.<String>builder()
-                .add("-chain=" + this.properties.getNetwork().getChain())
+                .add("-chain=" + this.properties.getChain().getChain())
                 .add("-rpcport=" + this.properties.getRpcport())
-                .add("-port=" + this.properties.getP2pport());
+                .add("-port=" + this.properties.getPort());
 
         List<String> overridingDefaults = ImmutableList.<String>builder()
                 // dns: Allow DNS lookups for -addnode, -seednode and -connect values.

--- a/spring-testcontainer/spring-testcontainer-bitcoind-starter/src/main/java/org/tbk/spring/testcontainer/bitcoind/config/BitcoindContainerProperties.java
+++ b/spring-testcontainer/spring-testcontainer-bitcoind-starter/src/main/java/org/tbk/spring/testcontainer/bitcoind/config/BitcoindContainerProperties.java
@@ -5,6 +5,8 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
@@ -39,6 +41,7 @@ import static com.google.common.base.Preconditions.checkArgument;
         prefix = "org.tbk.spring.testcontainer.bitcoind",
         ignoreUnknownFields = false
 )
+@Slf4j
 public class BitcoindContainerProperties extends AbstractContainerProperties implements Validator {
     private static final String DEFAULT_DOCKER_IMAGE_NAME = "polarlightning/bitcoind:25.0";
     private static final DockerImageName defaultDockerImageName = DockerImageName.parse(DEFAULT_DOCKER_IMAGE_NAME);
@@ -80,12 +83,17 @@ public class BitcoindContainerProperties extends AbstractContainerProperties imp
     /**
      * Bitcoin Network
      */
-    private String network = DEFAULT_CHAIN.toString();
+    private String network;
     
     /**
      * RPC port
      */
-    private Integer rpcport = REGTEST_DEFAULT_RPC_PORT;
+    private Integer rpcport;
+    
+    /**
+     * P2P Port
+     */
+    private Integer p2pport;
     
     /**
      * RPC username.
@@ -109,12 +117,43 @@ public class BitcoindContainerProperties extends AbstractContainerProperties imp
         return Optional.ofNullable(rpcpassword);
     }
     
-    public Optional<Integer> getRpcport(){
-    	return Optional.ofNullable(rpcport);
+    public Integer getRpcport(){
+    	Integer port = rpcport;
+		log.debug("RPC Port: {}" + this.rpcport);
+    	if(port == null) {
+    		log.debug("RPC Port not set...using default vaule");
+    		port = switch(getNetwork().toLowerCase()) {
+	    		case "mainnet" -> MAINNET_DEFAULT_RPC_PORT;
+	    		case "testnet" -> TESTNET_DEFAULT_RPC_PORT;
+	    		case "regtest" -> REGTEST_DEFAULT_RPC_PORT;
+	    		default -> throw new IllegalArgumentException("Invalid network: " + getNetwork());
+    		};//getNetwork never returns null, and must be
+    		//one of the above options, but need a default anyway
+    	}
+    	
+    	return port;
     }
 
-    public Optional<String> getNetwork(){
-    	return Optional.ofNullable(network);
+    public String getNetwork(){
+    	
+    	log.debug("Network: {}", this.network);
+    	return (this.network != null && !this.network.isBlank()) ? this.network : DEFAULT_CHAIN.toString();
+    }
+    
+    public Integer getP2pport() {
+    	Integer port = p2pport;
+    	log.debug("P2P Port: {}", p2pport);
+    	if(port == null) {
+    		log.debug("P2P Port not set...providing using default value");
+    		port = switch(getNetwork().toLowerCase()) {
+	    		case "mainnet" -> MAINNET_DEFAULT_P2P_PORT;
+	    		case "testnet" -> TESTNET_DEFAULT_P2P_PORT;
+	    		case "regtest" -> REGTEST_DEFAULT_P2P_PORT;
+	    		default -> throw new IllegalArgumentException("Invalid network: " + getNetwork());
+    		};//getNetwork never returns null, and must be
+    		//one of the above options, but need a default anyway
+    	}
+    	return port;
     }
     
     public Optional<String> getCommandValueByKey(String key) {
@@ -147,6 +186,7 @@ public class BitcoindContainerProperties extends AbstractContainerProperties imp
      */
     @Override
     public void validate(Object target, Errors errors) {
+
         BitcoindContainerProperties properties = (BitcoindContainerProperties) target;
 
         String rpcuserValue = properties.getRpcuser().orElse(null);
@@ -170,20 +210,26 @@ public class BitcoindContainerProperties extends AbstractContainerProperties imp
                 errors.rejectValue("rpcpassword", "rpcpassword.unsupported", errorMessage);
             }
         }
-        
-        Integer rpcportValue = properties.getRpcport().orElse(null);
-        if (rpcportValue != null && (rpcportValue < 0 || rpcportValue > 65535)) {
+
+        String networkValue = this.network;
+        if (networkValue != null &&
+                Arrays.stream(Chain.values()).noneMatch(
+                        c -> c.toString().contentEquals(networkValue))) {
+
+            String errorMessage = "'network' must be mainnet, regtest, or testnet - invalid network";
+            errors.rejectValue("network", "network.invalid", errorMessage);
+        }
+
+        Integer rpcportValue = this.rpcport;
+        if (rpcportValue != null && !portIsValid(rpcportValue)) {
         	String errorMessage = "'rpcport' must be in the range 0-65535 - invalid port.";
         	errors.rejectValue("rpcport", "rpcport.invalid", errorMessage);
         }
         
-        String networkValue = properties.getNetwork().orElse(null);
-        if (networkValue != null &&
-	        	Arrays.stream(Chain.values()).noneMatch(
-	        			c -> c.toString().contentEquals(networkValue))) {
-        	
-        	String errorMessage = "'network' must be mainnet, regtest, or testnet - invalid network";
-        	errors.rejectValue("network", "network.invalid", errorMessage);
+        Integer p2pport = this.p2pport;
+        if (p2pport != null && !portIsValid(p2pport)) {
+        	String errorMessage = "'p2pport' must be in the range 0-65535 - invalid port.";
+        	errors.rejectValue("p2pport", "p2pport.invalid", errorMessage);
         }
 
         reservedCommands.stream()
@@ -220,6 +266,10 @@ public class BitcoindContainerProperties extends AbstractContainerProperties imp
 
     private static boolean containsWhitespaces(String value) {
         return CharMatcher.whitespace().matchesAnyOf(value);
+    }
+    
+    private boolean portIsValid(Integer port) {
+    	return port >= 0 && port <= 65535;
     }
 }
 

--- a/spring-testcontainer/spring-testcontainer-bitcoind-starter/src/main/java/org/tbk/spring/testcontainer/bitcoind/config/BitcoindContainerProperties.java
+++ b/spring-testcontainer/spring-testcontainer-bitcoind-starter/src/main/java/org/tbk/spring/testcontainer/bitcoind/config/BitcoindContainerProperties.java
@@ -82,8 +82,7 @@ public class BitcoindContainerProperties extends AbstractContainerProperties imp
         super(defaultDockerImageName, reservedCommands);
     }
 
-    // TODO: rename to "chain"
-    private Chain network;
+    private Chain chain;
 
     /**
      * RPC port
@@ -93,8 +92,7 @@ public class BitcoindContainerProperties extends AbstractContainerProperties imp
     /**
      * P2P Port
      */
-    // TODO: rename to "port"
-    private Integer p2pport;
+    private Integer port;
 
     /**
      * RPC username.
@@ -106,8 +104,8 @@ public class BitcoindContainerProperties extends AbstractContainerProperties imp
      */
     private String rpcpassword;
 
-    public Chain getNetwork() {
-        return this.network != null ? this.network : DEFAULT_CHAIN;
+    public Chain getChain() {
+        return this.chain != null ? this.chain : DEFAULT_CHAIN;
     }
 
     public Optional<String> getRpcuser() {
@@ -119,15 +117,15 @@ public class BitcoindContainerProperties extends AbstractContainerProperties imp
     }
 
     public int getRpcport() {
-        return rpcport != null ? rpcport : switch (getNetwork()) {
+        return rpcport != null ? rpcport : switch (getChain()) {
             case mainnet -> MAINNET_DEFAULT_RPC_PORT;
             case testnet -> TESTNET_DEFAULT_RPC_PORT;
             case regtest -> REGTEST_DEFAULT_RPC_PORT;
         };
     }
 
-    public Integer getP2pport() {
-        return p2pport != null ? p2pport : switch (getNetwork()) {
+    public Integer getPort() {
+        return port != null ? port : switch (getChain()) {
             case mainnet -> MAINNET_DEFAULT_P2P_PORT;
             case testnet -> TESTNET_DEFAULT_P2P_PORT;
             case regtest -> REGTEST_DEFAULT_P2P_PORT;
@@ -194,10 +192,10 @@ public class BitcoindContainerProperties extends AbstractContainerProperties imp
             errors.rejectValue("rpcport", "rpcport.invalid", errorMessage);
         }
 
-        Integer p2pport = this.p2pport;
+        Integer p2pport = this.port;
         if (p2pport != null && !isValidPort(p2pport)) {
-            String errorMessage = "'p2pport' must be in the range 0-65535";
-            errors.rejectValue("p2pport", "p2pport.invalid", errorMessage);
+            String errorMessage = "'port' must be in the range 0-65535";
+            errors.rejectValue("port", "port.invalid", errorMessage);
         }
 
         reservedCommands.stream()

--- a/spring-testcontainer/spring-testcontainer-bitcoind-starter/src/test/java/org/tbk/spring/testcontainer/bitcoind/config/BitcoindContainerAutoConfigurationTest.java
+++ b/spring-testcontainer/spring-testcontainer-bitcoind-starter/src/test/java/org/tbk/spring/testcontainer/bitcoind/config/BitcoindContainerAutoConfigurationTest.java
@@ -59,7 +59,7 @@ class BitcoindContainerAutoConfigurationTest {
                     assertThat(properties, is(notNullValue()));
                     assertThat(properties.getRpcuser().orElseThrow(), is("myrpcuser"));
                     assertThat(properties.getRpcpassword().orElseThrow(), is("correcthorsebatterystaple"));
-                    assertThat(properties.getNetwork(), is(BitcoindContainerProperties.Chain.regtest));
+                    assertThat(properties.getChain(), is(BitcoindContainerProperties.Chain.regtest));
 
                     assertThat(properties.getCommands(), hasSize(3));
                     assertThat(properties.getCommands(), hasItem("-printtoconsole"));
@@ -156,7 +156,7 @@ class BitcoindContainerAutoConfigurationTest {
                         "org.tbk.spring.testcontainer.bitcoind.rpcuser=myrpcuser",
                         "org.tbk.spring.testcontainer.bitcoind.rpcpassword=password",
                         "org.tbk.spring.testcontainer.bitcoind.rpcport=7777",
-                        "org.tbk.spring.testcontainer.bitcoind.network=nakamoto",
+                        "org.tbk.spring.testcontainer.bitcoind.chain=nakamoto",
                         "org.tbk.spring.testcontainer.bitcoind.commands=-printtoconsole, -debug=1, -logips=1"
                 )
                 .run(context -> {
@@ -181,7 +181,7 @@ class BitcoindContainerAutoConfigurationTest {
                         "org.tbk.spring.testcontainer.bitcoind.rpcuser=myrpcuser",
                         "org.tbk.spring.testcontainer.bitcoind.rpcpassword=password",
                         "org.tbk.spring.testcontainer.bitcoind.rpcport=7777",
-                        "org.tbk.spring.testcontainer.bitcoind.p2pport=-1",
+                        "org.tbk.spring.testcontainer.bitcoind.port=-1",
                         "org.tbk.spring.testcontainer.bitcoind.commands=-printtoconsole, -debug=1, -logips=1"
                 )
                 .run(context -> {
@@ -194,9 +194,9 @@ class BitcoindContainerAutoConfigurationTest {
                         BindValidationException validationException = (BindValidationException) rootCause;
 
                         FieldError error = (FieldError) validationException.getValidationErrors().getAllErrors().get(0);
-                        assertThat(error.getField(), is("p2pport"));
-                        assertThat(error.getCode(), is("p2pport.invalid"));
-                        assertThat(error.getDefaultMessage(), is("'p2pport' must be in the range 0-65535"));
+                        assertThat(error.getField(), is("port"));
+                        assertThat(error.getCode(), is("port.invalid"));
+                        assertThat(error.getDefaultMessage(), is("'port' must be in the range 0-65535"));
                     }
                 });
     }
@@ -209,7 +209,7 @@ class BitcoindContainerAutoConfigurationTest {
                         "org.tbk.spring.testcontainer.bitcoind.rpcuser=myrpcuser",
                         "org.tbk.spring.testcontainer.bitcoind.rpcpassword=password",
                         "org.tbk.spring.testcontainer.bitcoind.rpcport=7777",
-                        "org.tbk.spring.testcontainer.bitcoind.p2pport=65536",
+                        "org.tbk.spring.testcontainer.bitcoind.port=65536",
                         "org.tbk.spring.testcontainer.bitcoind.commands=-printtoconsole, -debug=1, -logips=1"
                 )
                 .run(context -> {
@@ -222,9 +222,9 @@ class BitcoindContainerAutoConfigurationTest {
                         BindValidationException validationException = (BindValidationException) rootCause;
 
                         FieldError error = (FieldError) validationException.getValidationErrors().getAllErrors().get(0);
-                        assertThat(error.getField(), is("p2pport"));
-                        assertThat(error.getCode(), is("p2pport.invalid"));
-                        assertThat(error.getDefaultMessage(), is("'p2pport' must be in the range 0-65535"));
+                        assertThat(error.getField(), is("port"));
+                        assertThat(error.getCode(), is("port.invalid"));
+                        assertThat(error.getDefaultMessage(), is("'port' must be in the range 0-65535"));
                     }
                 });
     }
@@ -245,9 +245,9 @@ class BitcoindContainerAutoConfigurationTest {
                     BitcoindContainerProperties properties = context.getBean(BitcoindContainerProperties.class);
                     assertThat(properties, is(notNullValue()));
 
-                    assertThat(properties.getNetwork(), is(BitcoindContainerProperties.Chain.regtest));
+                    assertThat(properties.getChain(), is(BitcoindContainerProperties.Chain.regtest));
                     assertThat(properties.getRpcport(), is(18443));
-                    assertThat(properties.getP2pport(), is(18444));
+                    assertThat(properties.getPort(), is(18444));
 
                 });
     }
@@ -259,16 +259,16 @@ class BitcoindContainerAutoConfigurationTest {
                         "org.tbk.spring.testcontainer.bitcoind.enabled=true",
                         "org.tbk.spring.testcontainer.bitcoind.rpcuser=myrpcuser",
                         "org.tbk.spring.testcontainer.bitcoind.rpcpassword=correcthorsebatterystaple",
-                        "org.tbk.spring.testcontainer.bitcoind.network=mainnet",
+                        "org.tbk.spring.testcontainer.bitcoind.chain=mainnet",
                         "org.tbk.spring.testcontainer.bitcoind.commands=-printtoconsole, -debug=1, -logips=1"
                 )
                 .run(context -> {
                     BitcoindContainerProperties properties = context.getBean(BitcoindContainerProperties.class);
                     assertThat(properties, is(notNullValue()));
 
-                    assertThat(properties.getNetwork(), is(BitcoindContainerProperties.Chain.mainnet));
+                    assertThat(properties.getChain(), is(BitcoindContainerProperties.Chain.mainnet));
                     assertThat(properties.getRpcport(), is(8332));
-                    assertThat(properties.getP2pport(), is(8333));
+                    assertThat(properties.getPort(), is(8333));
                 });
     }
 
@@ -279,16 +279,16 @@ class BitcoindContainerAutoConfigurationTest {
                         "org.tbk.spring.testcontainer.bitcoind.enabled=true",
                         "org.tbk.spring.testcontainer.bitcoind.rpcuser=myrpcuser",
                         "org.tbk.spring.testcontainer.bitcoind.rpcpassword=correcthorsebatterystaple",
-                        "org.tbk.spring.testcontainer.bitcoind.network=testnet",
+                        "org.tbk.spring.testcontainer.bitcoind.chain=testnet",
                         "org.tbk.spring.testcontainer.bitcoind.commands=-printtoconsole, -debug=1, -logips=1"
                 )
                 .run(context -> {
                     BitcoindContainerProperties properties = context.getBean(BitcoindContainerProperties.class);
                     assertThat(properties, is(notNullValue()));
 
-                    assertThat(properties.getNetwork(), is(BitcoindContainerProperties.Chain.testnet));
+                    assertThat(properties.getChain(), is(BitcoindContainerProperties.Chain.testnet));
                     assertThat(properties.getRpcport(), is(18332));
-                    assertThat(properties.getP2pport(), is(18333));
+                    assertThat(properties.getPort(), is(18333));
                 });
     }
 }


### PR DESCRIPTION
Fixes #56.

- Add network and rpcport fields to properties class
- Add validation for the new fields
- Add unit tests