### PR TITLE
chore(release): v0.15.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0] - 2024-04-01
+
 ### Changed
 - upgrade: update lightning-kmp from v1.8.0 to v1.8.4
 - upgrade: update testcontainers from v1.19.8 to v1.20.4
@@ -306,7 +308,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release
 
-[Unreleased]: https://github.com/theborakompanioni/bitcoin-spring-boot-starter/compare/0.14.0...HEAD
+[Unreleased]: https://github.com/theborakompanioni/bitcoin-spring-boot-starter/compare/0.15.0...HEAD
+[0.15.0]: https://github.com/theborakompanioni/bitcoin-spring-boot-starter/compare/0.14.0...0.15.0
 [0.14.0]: https://github.com/theborakompanioni/bitcoin-spring-boot-starter/compare/0.13.0...0.14.0
 [0.13.0]: https://github.com/theborakompanioni/bitcoin-spring-boot-starter/compare/0.12.0...0.13.0
 [0.12.0]: https://github.com/theborakompanioni/bitcoin-spring-boot-starter/compare/0.11.0...0.12.0


### PR DESCRIPTION
### Changed
- upgrade: update lightning-kmp from v1.8.0 to v1.8.4
- upgrade: update testcontainers from v1.19.8 to v1.20.4
- upgrade: update cln-grpc-client from v24.8.1 to v24.11.1
- upgrade: update spring-tor from v0.8.0 to v0.9.0
- upgrade: update sqlite from v3.47.2.0 to v3.48.0.0
- upgrade: update hibernate-community-dialects from v6.6.1.Final to v6.6.5.Final
- upgrade: update lnd testcontainer from v0.18.2-beta to v0.18.4-beta
- upgrade: update lightningj from v0.17.0-Beta to v0.17.4-Beta

### Removed
- module: externalize 'bitcoin-fee' modules