### PR TITLE
refactor: use java HexFormat instead of acinq/bitcoinj utils

### DIFF
--- a/docker/regtest/bitcoin/docker-compose.yml
+++ b/docker/regtest/bitcoin/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: polarlightning/bitcoind:27.0@sha256:7ac359cacd1c667fae321fe049d3d860eb85f1f14aff805e96246c5dc70f2f13
     restart: no
     volumes:
-      - bitcoind-data:/home/bitcoin/.bitcoin/regtest
+      - bsbs-bitcoind-data:/home/bitcoin/.bitcoin/regtest
     command:
       -regtest=1
       -server=1
@@ -43,4 +43,4 @@ services:
       retries: 20
 
 volumes:
-  bitcoind-data:
+  bsbs-bitcoind-data:

--- a/examples/incubator/bitcoin-payment-request-example-application/src/main/java/org/tbk/bitcoin/example/payreq/bitcoin/chaininfo/BitcoinChainInfoServiceImpl.java
+++ b/examples/incubator/bitcoin-payment-request-example-application/src/main/java/org/tbk/bitcoin/example/payreq/bitcoin/chaininfo/BitcoinChainInfoServiceImpl.java
@@ -4,7 +4,6 @@ import com.google.common.base.MoreObjects;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.bitcoinj.core.Utils;
 import org.consensusj.bitcoin.json.pojo.BlockChainInfo;
 import org.jmolecules.ddd.annotation.Service;
 import org.springframework.dao.EmptyResultDataAccessException;
@@ -12,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionalEventListener;
 
 import java.math.BigDecimal;
+import java.util.HexFormat;
 import java.util.Optional;
 
 @Slf4j
@@ -34,7 +34,7 @@ class BitcoinChainInfoServiceImpl implements BitcoinChainInfoService {
     @Transactional
     public void createChainInfo(BlockChainInfo info) {
         String chainWork = Optional.ofNullable(info.getChainWork())
-                .map(Utils.HEX::encode)
+                .map(it -> HexFormat.of().formatHex(it))
                 .orElse("");
 
         BitcoinChainInfo bitcoinChainInfo = new BitcoinChainInfo(

--- a/examples/incubator/bitcoin-payment-request-example-application/src/main/java/org/tbk/bitcoin/example/payreq/payment/LndInvoicePaymentRequest.java
+++ b/examples/incubator/bitcoin-payment-request-example-application/src/main/java/org/tbk/bitcoin/example/payreq/payment/LndInvoicePaymentRequest.java
@@ -6,11 +6,11 @@ import jakarta.persistence.Column;
 import lombok.Getter;
 import lombok.Value;
 import org.bitcoinj.core.NetworkParameters;
-import org.springframework.security.crypto.codec.Hex;
 import org.tbk.bitcoin.example.payreq.common.Network;
 import org.tbk.bitcoin.example.payreq.order.Order;
 
 import java.time.Instant;
+import java.util.HexFormat;
 
 import static java.util.Objects.requireNonNull;
 
@@ -43,7 +43,7 @@ public class LndInvoicePaymentRequest extends PaymentRequest {
         this.validUntil = requireNonNull(validUntil);
         this.network = Network.fromNetworkParameters(network).name();
         this.paymentHash = requireNonNull(paymentHash);
-        this.rhash = String.valueOf(Hex.encode(rHash));
+        this.rhash = HexFormat.of().formatHex(rHash);
 
         registerEvent(LightningPaymentRequestCreatedEvent.of(this.getId()));
     }

--- a/examples/incubator/bitcoin-payment-request-example-application/src/main/java/org/tbk/bitcoin/example/payreq/payment/LndInvoicePaymentRequestListener.java
+++ b/examples/incubator/bitcoin-payment-request-example-application/src/main/java/org/tbk/bitcoin/example/payreq/payment/LndInvoicePaymentRequestListener.java
@@ -12,8 +12,9 @@ import org.lightningj.lnd.wrapper.message.InvoiceSubscription;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
-import org.springframework.security.crypto.codec.Hex;
 import org.springframework.stereotype.Component;
+
+import java.util.HexFormat;
 
 @Slf4j
 @Component
@@ -42,7 +43,7 @@ class LndInvoicePaymentRequestListener {
                 @Override
                 public void onNext(Invoice value) {
                     try {
-                        String rHash = String.valueOf(Hex.encode(value.getRHash()));
+                        String rHash = HexFormat.of().formatHex(value.getRHash());
                         lightningPaymentRequests.findByRhash(rHash)
                                 .map(PaymentRequest::getId)
                                 .ifPresent(paymentRequestService::reevaluatePaymentRequestById);

--- a/incubator/bitcoin-bip85/src/test/java/org/tbk/bitcoin/bip85/DeterministicEntropyTest.java
+++ b/incubator/bitcoin-bip85/src/test/java/org/tbk/bitcoin/bip85/DeterministicEntropyTest.java
@@ -3,8 +3,9 @@ package org.tbk.bitcoin.bip85;
 import fr.acinq.bitcoin.DeterministicWallet;
 import fr.acinq.bitcoin.KeyPath;
 import fr.acinq.bitcoin.MnemonicCode;
-import fr.acinq.secp256k1.Hex;
 import org.junit.jupiter.api.Test;
+
+import java.util.HexFormat;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -31,7 +32,7 @@ class DeterministicEntropyTest {
         DeterministicWallet.ExtendedPrivateKey masterBip32RootKey = DeterministicWallet.ExtendedPrivateKey.decode(xprv, KeyPath.fromPath("")).getSecond();
 
         byte[] entropy = DeterministicEntropy.keyToEntropy(masterBip32RootKey, 0);
-        String entropyHex = Hex.encode(entropy);
+        String entropyHex = HexFormat.of().formatHex(entropy);
 
         assertThat(entropyHex, is("efecfbccffea313214232d29e71563d941229afb4338c21f9517c41aaa0d16f00b83d2a09ef747e7a64e8e2bd5a14869e693da66ce94ac2da570ab7ee48618f7"));
     }
@@ -42,7 +43,7 @@ class DeterministicEntropyTest {
         DeterministicWallet.ExtendedPrivateKey masterBip32RootKey = DeterministicWallet.ExtendedPrivateKey.decode(xprv, KeyPath.fromPath("")).getSecond();
 
         byte[] entropy = DeterministicEntropy.keyToEntropy(masterBip32RootKey, 1);
-        String entropyHex = Hex.encode(entropy);
+        String entropyHex = HexFormat.of().formatHex(entropy);
 
         assertThat(entropyHex, is("70c6e3e8ebee8dc4c0dbba66076819bb8c09672527c4277ca8729532ad711872218f826919f6b67218adde99018a6df9095ab2b58d803b5b93ec9802085a690e"));
     }
@@ -91,7 +92,8 @@ class DeterministicEntropyTest {
         DeterministicWallet.ExtendedPrivateKey masterBip32RootKey = DeterministicWallet.ExtendedPrivateKey.decode(xprv, KeyPath.fromPath("")).getSecond();
 
         byte[] entropy = DeterministicEntropy.keyToHex(masterBip32RootKey, 64, 0);
-        assertThat(Hex.encode(entropy), is("492db4698cf3b73a5a24998aa3e9d7fa96275d85724a91e71aa2d645442f878555d078fd1f1f67e368976f04137b1f7a0d19232136ca50c44614af72b5582a5c"));
+        String entropyHex = HexFormat.of().formatHex(entropy);
+        assertThat(entropyHex, is("492db4698cf3b73a5a24998aa3e9d7fa96275d85724a91e71aa2d645442f878555d078fd1f1f67e368976f04137b1f7a0d19232136ca50c44614af72b5582a5c"));
     }
 
     // https://github.com/hoganri/bip85-js/blob/main/test.js
@@ -102,7 +104,7 @@ class DeterministicEntropyTest {
         DeterministicWallet.ExtendedPrivateKey masterBip32RootKey = DeterministicWallet.generate(seed);
 
         byte[] entropy = DeterministicEntropy.keyToEntropy(masterBip32RootKey, 0);
-        String entropyHex = Hex.encode(entropy);
+        String entropyHex = HexFormat.of().formatHex(entropy);
 
         assertThat(entropyHex, is("d24cee04c61c4a47751658d078ae9b0cc9550fe43eee643d5c10ac2e3f5edbca757b2bd74d55ff5bcc2b1608d567053660d9c7447ae1eb84b6619282fd391844"));
     }

--- a/incubator/lnurl-java/lnurl-simple/src/main/java/org/tbk/lnurl/simple/auth/AbstractByteArrayView.java
+++ b/incubator/lnurl-java/lnurl-simple/src/main/java/org/tbk/lnurl/simple/auth/AbstractByteArrayView.java
@@ -1,10 +1,10 @@
 package org.tbk.lnurl.simple.auth;
 
-import fr.acinq.secp256k1.Hex;
 import lombok.EqualsAndHashCode;
 import org.tbk.lnurl.auth.ByteArrayView;
 
 import java.util.Arrays;
+import java.util.HexFormat;
 
 import static java.util.Objects.requireNonNull;
 
@@ -32,7 +32,7 @@ abstract class AbstractByteArrayView implements ByteArrayView {
 
     public String toHex() {
         if (hex == null) {
-            hex = Hex.encode(data);
+            hex = HexFormat.of().formatHex(data);
         }
         return hex;
     }

--- a/incubator/lnurl-java/lnurl-simple/src/test/java/org/tbk/lnurl/simple/auth/SimpleLinkingKeyTest.java
+++ b/incubator/lnurl-java/lnurl-simple/src/test/java/org/tbk/lnurl/simple/auth/SimpleLinkingKeyTest.java
@@ -5,6 +5,8 @@ import fr.acinq.secp256k1.Hex;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.HexFormat;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
@@ -30,7 +32,7 @@ class SimpleLinkingKeyTest {
     @Test
     void fromHexSuccessWithCompressedValidSecp256k1PublicKey() {
         String uncompressedValidLinkingKeyHex = "0465d6177992064a24c24213230a0c3eeb5f2047c7286391c7ead608cda473f787af9afcae9af3a6a84f28a775ad257dbf6027448461455aaf482569237dda27bd";
-        String compressedValidLinkingKeyHex = Hex.encode(PublicKey.compress(Hex.decode(uncompressedValidLinkingKeyHex)));
+        String compressedValidLinkingKeyHex = HexFormat.of().formatHex(PublicKey.compress(HexFormat.of().parseHex(uncompressedValidLinkingKeyHex)));
 
         assertThat(compressedValidLinkingKeyHex, is("0365d6177992064a24c24213230a0c3eeb5f2047c7286391c7ead608cda473f787"));
 

--- a/incubator/spring-lnurl/spring-lnurl-auth-example-application/src/exampleTest/java/org/tbk/lightning/lnurl/example/domain/WalletUserServiceImplIntegrationTest.java
+++ b/incubator/spring-lnurl/spring-lnurl-auth-example-application/src/exampleTest/java/org/tbk/lightning/lnurl/example/domain/WalletUserServiceImplIntegrationTest.java
@@ -1,7 +1,6 @@
 package org.tbk.lightning.lnurl.example.domain;
 
 import fr.acinq.bitcoin.PublicKey;
-import fr.acinq.secp256k1.Hex;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -9,6 +8,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 import org.tbk.lnurl.simple.auth.SimpleLinkingKey;
 
+import java.util.HexFormat;
 import java.util.List;
 import java.util.Optional;
 
@@ -27,7 +27,7 @@ class WalletUserServiceImplIntegrationTest {
     @Transactional
     void itShouldCreateNewUserIfMissing() {
         String uncompressedValidLinkingKeyHex = "0465d6177992064a24c24213230a0c3eeb5f2047c7286391c7ead608cda473f787af9afcae9af3a6a84f28a775ad257dbf6027448461455aaf482569237dda27bd";
-        String compressedValidLinkingKeyHex = Hex.encode(PublicKey.compress(Hex.decode(uncompressedValidLinkingKeyHex)));
+        String compressedValidLinkingKeyHex = HexFormat.of().formatHex(PublicKey.compress(HexFormat.of().parseHex(uncompressedValidLinkingKeyHex)));
 
         SimpleLinkingKey linkingKey = SimpleLinkingKey.fromHex(compressedValidLinkingKeyHex);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Migrated hex encoding across multiple components to use Java's native HexFormat utility instead of external libraries, improving code standardization and reducing external dependencies.

* **Chores**
  * Updated Docker volume naming for improved consistency in test infrastructure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->