### PR TITLE
fix: logging file name in example applications

### DIFF
--- a/bitcoin-jsonrpc-client/bitcoin-jsonrpc-client-example-application/src/main/resources/application-development.yml
+++ b/bitcoin-jsonrpc-client/bitcoin-jsonrpc-client-example-application/src/main/resources/application-development.yml
@@ -10,7 +10,7 @@ server.compression.enabled: true
 
 management.server.port: 9001
 
-# LOGGING# LOGGING
+# LOGGING
 logging.file.path: ./var/log
 logging.file.name: ${logging.file.path}/application-dev.log
 logging.config: classpath:logback-development.xml

--- a/bitcoin-jsonrpc-client/bitcoin-jsonrpc-client-example-application/src/main/resources/application-development.yml
+++ b/bitcoin-jsonrpc-client/bitcoin-jsonrpc-client-example-application/src/main/resources/application-development.yml
@@ -10,8 +10,9 @@ server.compression.enabled: true
 
 management.server.port: 9001
 
-# LOGGING
-logging.file.name: application-dev.log
+# LOGGING# LOGGING
+logging.file.path: ./var/log
+logging.file.name: ${logging.file.path}/application-dev.log
 logging.config: classpath:logback-development.xml
 logging.level.org.springframework: INFO
 logging.level.org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping: TRACE

--- a/bitcoin-jsonrpc-client/bitcoin-jsonrpc-client-example-application/src/main/resources/application.yml
+++ b/bitcoin-jsonrpc-client/bitcoin-jsonrpc-client-example-application/src/main/resources/application.yml
@@ -9,7 +9,7 @@ server.compression.enabled: true
 
 management.server.port: 9001
 
-# LOGGING# LOGGING
+# LOGGING
 logging.file.path: ./var/log
 logging.file.name: ${logging.file.path}/application.log
 logging.config: classpath:logback.xml

--- a/bitcoin-jsonrpc-client/bitcoin-jsonrpc-client-example-application/src/main/resources/application.yml
+++ b/bitcoin-jsonrpc-client/bitcoin-jsonrpc-client-example-application/src/main/resources/application.yml
@@ -9,8 +9,9 @@ server.compression.enabled: true
 
 management.server.port: 9001
 
-# LOGGING
-logging.file.name: application.log
+# LOGGING# LOGGING
+logging.file.path: ./var/log
+logging.file.name: ${logging.file.path}/application.log
 logging.config: classpath:logback.xml
 logging.level.org.springframework: INFO
 logging.level.org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping: TRACE

--- a/bitcoin-regtest/bitcoin-regtest-example-application/src/main/resources/application-development.yml
+++ b/bitcoin-regtest/bitcoin-regtest-example-application/src/main/resources/application-development.yml
@@ -11,7 +11,8 @@ server.compression.enabled: true
 management.server.port: 9001
 
 # LOGGING
-logging.file.name: application-dev.log
+logging.file.path: ./var/log
+logging.file.name: ${logging.file.path}/application-dev.log
 logging.config: classpath:logback-development.xml
 logging.level.org.springframework: INFO
 logging.level.org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping: INFO # TRACE

--- a/bitcoin-regtest/bitcoin-regtest-example-application/src/main/resources/application.yml
+++ b/bitcoin-regtest/bitcoin-regtest-example-application/src/main/resources/application.yml
@@ -11,7 +11,7 @@ management.server.port: 9001
 
 # LOGGING
 logging.file.path: ./var/log
-logging.file.name: application.log
+logging.file.name: ${logging.file.path}/application.log
 logging.config: classpath:logback.xml
 logging.level.org.springframework: INFO
 logging.level.org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping: TRACE

--- a/bitcoin-zeromq-client/bitcoin-zeromq-client-example-application/src/main/resources/application-development.yml
+++ b/bitcoin-zeromq-client/bitcoin-zeromq-client-example-application/src/main/resources/application-development.yml
@@ -11,7 +11,8 @@ server.compression.enabled: true
 management.server.port: 9001
 
 # LOGGING
-logging.file.name: application-dev.log
+logging.file.path: ./var/log
+logging.file.name: ${logging.file.path}/application-dev.log
 logging.config: classpath:logback-development.xml
 logging.level.org.springframework: INFO
 logging.level.org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping: TRACE

--- a/bitcoin-zeromq-client/bitcoin-zeromq-client-example-application/src/main/resources/application.yml
+++ b/bitcoin-zeromq-client/bitcoin-zeromq-client-example-application/src/main/resources/application.yml
@@ -10,7 +10,8 @@ server.compression.enabled: true
 management.server.port: 9001
 
 # LOGGING
-logging.file.name: application.log
+logging.file.path: ./var/log
+logging.file.name: ${logging.file.path}/application.log
 logging.config: classpath:logback.xml
 logging.level.org.springframework: INFO
 logging.level.org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping: TRACE

--- a/examples/bitcoin-exchange-rate-example-application/src/main/resources/application-development.yml
+++ b/examples/bitcoin-exchange-rate-example-application/src/main/resources/application-development.yml
@@ -12,7 +12,7 @@ management.server.port: 9001
 
 # LOGGING
 logging.file.path: ./var/log
-logging.file.name: application-dev.log
+logging.file.name: ${logging.file.path}/application-dev.log
 logging.config: classpath:logback-development.xml
 logging.level.org.springframework: INFO
 logging.level.org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping: TRACE

--- a/examples/bitcoin-exchange-rate-example-application/src/main/resources/application.yml
+++ b/examples/bitcoin-exchange-rate-example-application/src/main/resources/application.yml
@@ -11,7 +11,7 @@ management.server.port: 9001
 
 # LOGGING
 logging.file.path: ./var/log
-logging.file.name: application.log
+logging.file.name: ${logging.file.path}/application.log
 logging.config: classpath:logback.xml
 logging.level.org.springframework: INFO
 logging.level.org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping: TRACE

--- a/examples/incubator/bitcoin-payment-request-example-application/src/main/resources/application-development.yml
+++ b/examples/incubator/bitcoin-payment-request-example-application/src/main/resources/application-development.yml
@@ -19,7 +19,7 @@ spring.datasource.url: 'jdbc:sqlite:bitcoin_payment_request_example_application-
 
 # LOGGING
 logging.file.path: ./var/log
-logging.file.name: application-dev.log
+logging.file.name: ${logging.file.path}/application-dev.log
 logging.config: classpath:logback-development.xml
 logging.level.org.springframework: INFO
 #logging.level.org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping: TRACE

--- a/examples/incubator/bitcoin-payment-request-example-application/src/main/resources/application.yml
+++ b/examples/incubator/bitcoin-payment-request-example-application/src/main/resources/application.yml
@@ -23,7 +23,7 @@ management.health.lndApi.enabled: true
 
 # LOGGING
 logging.file.path: ./var/log
-logging.file.name: application.log
+logging.file.name: ${logging.file.path}/application.log
 logging.config: classpath:logback.xml
 logging.level.org.springframework: INFO
 #logging.level.org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping: TRACE

--- a/examples/ln-playground-example-application/src/main/resources/application-development.yml
+++ b/examples/ln-playground-example-application/src/main/resources/application-development.yml
@@ -12,7 +12,7 @@ management.server.port: 9001
 
 # LOGGING
 logging.file.path: ./var/log
-logging.file.name: application-dev.log
+logging.file.name: ${logging.file.path}/application-dev.log
 logging.config: classpath:logback-development.xml
 logging.level.org.springframework: INFO
 logging.level.org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping: TRACE

--- a/examples/ln-playground-example-application/src/main/resources/application.yml
+++ b/examples/ln-playground-example-application/src/main/resources/application.yml
@@ -11,7 +11,7 @@ management.server.port: 9001
 
 # LOGGING
 logging.file.path: ./var/log
-logging.file.name: application.log
+logging.file.name: ${logging.file.path}/application.log
 logging.config: classpath:logback.xml
 logging.level.org.springframework: INFO
 logging.level.org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping: TRACE

--- a/incubator/spring-lnurl/spring-lnurl-auth-example-application/src/main/resources/application-development.yml
+++ b/incubator/spring-lnurl/spring-lnurl-auth-example-application/src/main/resources/application-development.yml
@@ -14,7 +14,7 @@ spring.datasource.url: 'jdbc:sqlite:lnurl_auth_example_application-dev.db?foreig
 
 # LOGGING
 logging.file.path: ./var/log
-logging.file.name: application-dev.log
+logging.file.name: ${logging.file.path}/application-dev.log
 logging.config: classpath:logback-development.xml
 logging.level.org.springframework: INFO
 logging.level.org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping: TRACE

--- a/incubator/spring-lnurl/spring-lnurl-auth-example-application/src/main/resources/application.yml
+++ b/incubator/spring-lnurl/spring-lnurl-auth-example-application/src/main/resources/application.yml
@@ -33,7 +33,7 @@ management.server.port: 9001
 
 # LOGGING
 logging.file.path: ./var/log
-logging.file.name: application.log
+logging.file.name: ${logging.file.path}/application.log
 logging.config: classpath:logback.xml
 logging.level.org.springframework: INFO
 logging.level.org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping: TRACE

--- a/spring-testcontainer/spring-testcontainer-bitcoind-example-application/src/main/resources/application-development.yml
+++ b/spring-testcontainer/spring-testcontainer-bitcoind-example-application/src/main/resources/application-development.yml
@@ -11,7 +11,7 @@ management.server.port: 9001
 
 # LOGGING
 logging.file.path: ./var/log
-logging.file.name: application-dev.log
+logging.file.name: ${logging.file.path}/application-dev.log
 logging.config: classpath:logback-development.xml
 logging.level.org.springframework: INFO
 logging.level.org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping: TRACE

--- a/spring-testcontainer/spring-testcontainer-bitcoind-example-application/src/main/resources/application.yml
+++ b/spring-testcontainer/spring-testcontainer-bitcoind-example-application/src/main/resources/application.yml
@@ -11,7 +11,7 @@ management.server.port: 9001
 
 # LOGGING
 logging.file.path: ./var/log
-logging.file.name: application.log
+logging.file.name: ${logging.file.path}/application.log
 logging.config: classpath:logback.xml
 logging.level.org.springframework: INFO
 logging.level.org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping: TRACE

--- a/spring-testcontainer/spring-testcontainer-btc-rpc-explorer-example-application/src/main/resources/application-development.yml
+++ b/spring-testcontainer/spring-testcontainer-btc-rpc-explorer-example-application/src/main/resources/application-development.yml
@@ -12,7 +12,7 @@ management.server.port: 9001
 
 # LOGGING
 logging.file.path: ./var/log
-logging.file.name: application-dev.log
+logging.file.name: ${logging.file.path}/application-dev.log
 logging.config: classpath:logback-development.xml
 logging.level.org.springframework: INFO
 logging.level.org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping: TRACE

--- a/spring-testcontainer/spring-testcontainer-btc-rpc-explorer-example-application/src/main/resources/application.yml
+++ b/spring-testcontainer/spring-testcontainer-btc-rpc-explorer-example-application/src/main/resources/application.yml
@@ -11,7 +11,7 @@ management.server.port: 9001
 
 # LOGGING
 logging.file.path: ./var/log
-logging.file.name: application.log
+logging.file.name: ${logging.file.path}/application.log
 logging.config: classpath:logback.xml
 logging.level.org.springframework: INFO
 logging.level.org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping: TRACE

--- a/spring-testcontainer/spring-testcontainer-cln-example-application/src/main/resources/application-development.yml
+++ b/spring-testcontainer/spring-testcontainer-cln-example-application/src/main/resources/application-development.yml
@@ -12,7 +12,7 @@ management.server.port: 9001
 
 # LOGGING
 logging.file.path: ./var/log
-logging.file.name: application-dev.log
+logging.file.name: ${logging.file.path}/application-dev.log
 logging.config: classpath:logback-development.xml
 logging.level.org.springframework: INFO
 logging.level.org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping: TRACE

--- a/spring-testcontainer/spring-testcontainer-cln-example-application/src/main/resources/application.yml
+++ b/spring-testcontainer/spring-testcontainer-cln-example-application/src/main/resources/application.yml
@@ -11,7 +11,7 @@ management.server.port: 9001
 
 # LOGGING
 logging.file.path: ./var/log
-logging.file.name: application.log
+logging.file.name: ${logging.file.path}/application.log
 logging.config: classpath:logback.xml
 logging.level.org.springframework: INFO
 logging.level.org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping: TRACE

--- a/spring-testcontainer/spring-testcontainer-lnd-example-application/src/main/resources/application-development.yml
+++ b/spring-testcontainer/spring-testcontainer-lnd-example-application/src/main/resources/application-development.yml
@@ -12,7 +12,7 @@ management.server.port: 9001
 
 # LOGGING
 logging.file.path: ./var/log
-logging.file.name: application-dev.log
+logging.file.name: ${logging.file.path}/application-dev.log
 logging.config: classpath:logback-development.xml
 logging.level.org.springframework: INFO
 logging.level.org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping: TRACE

--- a/spring-testcontainer/spring-testcontainer-lnd-example-application/src/main/resources/application.yml
+++ b/spring-testcontainer/spring-testcontainer-lnd-example-application/src/main/resources/application.yml
@@ -11,7 +11,7 @@ management.server.port: 9001
 
 # LOGGING
 logging.file.path: ./var/log
-logging.file.name: application.log
+logging.file.name: ${logging.file.path}/application.log
 logging.config: classpath:logback.xml
 logging.level.org.springframework: INFO
 logging.level.org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping: TRACE

--- a/spring-testcontainer/spring-testcontainer-tor-example-application/src/main/resources/application-development.yml
+++ b/spring-testcontainer/spring-testcontainer-tor-example-application/src/main/resources/application-development.yml
@@ -12,7 +12,7 @@ management.server.port: 9001
 
 # LOGGING
 logging.file.path: ./var/log
-logging.file.name: application-dev.log
+logging.file.name: ${logging.file.path}/application-dev.log
 logging.config: classpath:logback-development.xml
 logging.level.org.springframework: INFO
 logging.level.org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping: TRACE

--- a/spring-testcontainer/spring-testcontainer-tor-example-application/src/main/resources/application.yml
+++ b/spring-testcontainer/spring-testcontainer-tor-example-application/src/main/resources/application.yml
@@ -11,7 +11,7 @@ management.server.port: 9001
 
 # LOGGING
 logging.file.path: ./var/log
-logging.file.name: application.log
+logging.file.name: ${logging.file.path}/application.log
 logging.config: classpath:logback.xml
 logging.level.org.springframework: INFO
 logging.level.org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping: TRACE


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized logging across all example applications to use a configurable log directory (log file names now reference a common path variable) for both development and production configs.
  * Minor logging tweak: enabled DEBUG level for web logging in the development configuration where applicable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->